### PR TITLE
Add Pandoc fallbacks, authenticated exports, and Obsidian-safe output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Unit test / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.nox/
+coverage.xml
+*.cover
+.hypothesis/
+
+# Type checkers
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pytype/
+
+# Linters / formatters
+.ruff_cache/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# IDE
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MediaWiki to Markdown Vault Converter 🧭
 
-This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vault — including images, categories, infoboxes, and structured YAML frontmatter.
+This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vault — including images, categories, Obsidian callouts from wiki templates, and YAML frontmatter for titles and tags.
 
 🧭 If you're looking for a worldbuilding tool to connect your ideas, check out my app [Chronicler](https://chronicler.pro/) (source available [here](https://github.com/mak-kirkland/chronicler))
 
@@ -9,12 +9,12 @@ This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vaul
 ## ✨ Features
 
 - ✅ Converts MediaWiki pages to Obsidian-compatible Markdown
-- 🏷️ Extracts and normalizes categories as `tags`
-- 📦 Converts infoboxes into YAML frontmatter (including images)
-- 🔧 Infers tags from infobox types using noun inflection
+- 🏷️ Extracts and normalizes categories as `tags`, rewriting category wikilinks to `[[Index …]]` pages
+- 📦 Converts all `{{templates}}` into Obsidian callout blocks in place (infoboxes, navboxes, etc.)
+- 📄 On `Template:` namespace pages, preserves the original wikitext in a reference source block
 - 🖼️ Downloads and embeds images as `![[images/Filename]]` (supports `File:`, `Image:`, and `Media:` links)
 - 🔗 Converts internal links to Obsidian-safe `[[Wikilinks]]` via Pandoc post-processing
-- 📚 Automatically generates tag-based index files under `_indexes/`
+- 📚 Automatically generates tag-based index files under `indexes/` (e.g. `Index Characters.md`)
 - 🐢 Uses Pandoc for wikitext-to-Markdown conversion when available (recommended; falls back to raw wikitext on failure)
 - ⏭️ Optional `--skip-pandoc` flag to bypass Pandoc conversion entirely and keep raw wikitext
 - 🔐 Optional `--cookies` flag for authenticated wikis (private wikis, login-required image downloads)
@@ -44,9 +44,8 @@ Python dependencies are listed in `requirements.txt`. All packages use pinned ve
 | ------------------ | -------------------------------------- |
 | `mwparserfromhell` | Parse and manipulate wikitext          |
 | `requests`         | Download images from the wiki API      |
-| `pyyaml`           | Generate YAML frontmatter              |
+| `pyyaml`           | Generate YAML frontmatter (title/tags) |
 | `tqdm`             | Progress bar during conversion         |
-| `inflect`          | Infer tags from infobox template names |
 
 ## 🛠️ Installation
 
@@ -310,7 +309,7 @@ python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--skip-pandoc] [--v
 
 ### Skipping Pandoc (`--skip-pandoc`)
 
-Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, infoboxes, images, and YAML frontmatter are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
+Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, infobox callouts, images, and YAML frontmatter (title and tags) are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
 
 ```bash
 python convert.py wiki-dump.xml --skip-pandoc
@@ -318,7 +317,11 @@ python convert.py wiki-dump.xml --skip-pandoc
 
 ### Authenticated wikis (`--cookies`)
 
-If the wiki requires login to access images or the API, copy the `Cookie` header from an authenticated browser session (e.g. Developer Tools → Network → any request → Request Headers) and pass it to the script:
+Some wikis only allow logged-in users to download images or use the API. If you see a permission error during conversion, pass the `Cookie` header from an authenticated browser session:
+
+1. Log in to the wiki in your browser.
+2. Open Developer Tools → **Network**, reload a page, and copy the `Cookie` value from any request's headers.
+3. Run the script with `--cookies`:
 
 ```bash
 python convert.py wiki-dump.xml --cookies "sessionid=abc123; csrftoken=xyz789"
@@ -330,9 +333,9 @@ python convert.py wiki-dump.xml --cookies "sessionid=abc123; csrftoken=xyz789"
 
 ```text
 obsidian_vault/
-├── _indexes/
-│   ├── _people.md
-│   ├── _locations.md
+├── indexes/
+│   ├── Index Characters.md
+│   ├── Index Locations.md
 │   └── ...
 ├── images/
 │   ├── Example.jpg
@@ -341,6 +344,17 @@ obsidian_vault/
 ├── Page_Title_2.md
 └── ...
 ```
+
+Each converted page includes YAML frontmatter with `title` and `tags`. Wiki templates render as Obsidian callouts in place — wherever the template appeared in the original wikitext:
+
+```markdown
+> [!character]
+> - **name**: Aragorn
+> - **race**: [[Human]]
+> - **image**: ![[images/Aragorn.jpg]]
+```
+
+Category wikilinks in the body become links to the matching index page (e.g. `[[Index Characters]]` → `indexes/Index Characters.md`). Pages in the `Template:` namespace also include the original MediaWiki source in a preserved block for reference.
 
 ## 👤 Author
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ If you find this script useful, please consider supporting me on Patreon:
 - Python 3.8+ (already installed — see **Installation** below for the rest)
 - [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it)
 
+  Pandoc integration (including wikilink post-processing) has been tested with **Pandoc 3.9.0.2**. Other versions may work, but Pandoc's Markdown output can change between releases.
+
 Python dependencies are listed in `requirements.txt`. All packages use pinned versions (`~=`) for compatibility across environments. You are free to remove the version constraints and try the latest (or older) releases if you prefer — just keep in mind that unpinned installs may introduce breaking changes.
 
 | Package            | Purpose                                |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MediaWiki to Markdown Vault Converter 🧭
 
-This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vault — including images, categories, Obsidian callouts from wiki templates, and YAML frontmatter for titles and tags.
+This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vault — including images, categories, Obsidian callouts from wiki templates, YAML frontmatter for titles and tags, and provenance fields linking each page back to the original wiki.
 
 🧭 If you're looking for a worldbuilding tool to connect your ideas, check out my app [Chronicler](https://chronicler.pro/) (source available [here](https://github.com/mak-kirkland/chronicler))
 
@@ -10,6 +10,7 @@ This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vaul
 
 - ✅ Converts MediaWiki pages to Obsidian-compatible Markdown
 - 🏷️ Extracts and normalizes categories as `tags`, rewriting category wikilinks to `[[Index …]]` pages
+- 📋 Adds YAML `source/*` fields on each page — wiki generator, site URL, page URL, and revision date
 - 📦 Converts all `{{templates}}` into Obsidian callout blocks in place (infoboxes, navboxes, etc.)
 - 📄 On `Template:` namespace pages, preserves the original wikitext in a reference source block
 - 🖼️ Downloads and embeds images as `![[images/Filename]]` (supports `File:`, `Image:`, and `Media:` links)
@@ -45,7 +46,7 @@ Python dependencies are listed in `requirements.txt`. All packages use pinned ve
 | ------------------ | -------------------------------------- |
 | `mwparserfromhell` | Parse and manipulate wikitext          |
 | `requests`         | Download images from the wiki API      |
-| `pyyaml`           | Generate YAML frontmatter (title/tags) |
+| `pyyaml`           | Generate YAML frontmatter (title, tags, source) |
 | `tqdm`             | Progress bar during conversion         |
 
 ## 🛠️ Installation
@@ -238,7 +239,7 @@ pandoc --version
 
 ## 📥 Creating the input XML file
 
-`convert.py` expects a MediaWiki XML export — the same format produced by [Special:Export](https://www.mediawiki.org/wiki/Special:Export) or `dumpBackup.php`. The file must include a `<base>` URL in `<siteinfo>` so the script can resolve image downloads.
+`convert.py` expects a MediaWiki XML export — the same format produced by [Special:Export](https://www.mediawiki.org/wiki/Special:Export) or `dumpBackup.php`. The file must include `<siteinfo>` with a `<base>` URL (for image downloads and page links) and a `<generator>` tag (for the source note in frontmatter).
 
 ### CLI (preferred)
 
@@ -311,7 +312,7 @@ python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--pandoc-skip] [--p
 
 ### Skipping Pandoc (`--pandoc-skip`)
 
-Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, template callouts, images, and YAML frontmatter (title and tags) are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
+Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, template callouts, images, YAML frontmatter (title, tags, and source fields), and image downloads are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
 
 ```bash
 python convert.py wiki-dump.xml --pandoc-skip
@@ -371,7 +372,28 @@ obsidian_vault/
 └── ...
 ```
 
-Each converted page includes YAML frontmatter with `title` and `tags`. Wiki templates render as Obsidian callouts in place — wherever the template appeared in the original wikitext:
+Each converted page includes YAML frontmatter with `title`, `tags`, and source provenance read from the XML export:
+
+```yaml
+---
+title: Aragorn
+tags:
+  - Characters
+source/note: Imported from MediaWiki 1.41.0 website @ https://your-wiki.example
+source/url: https://your-wiki.example/wiki/Aragorn
+source/date: '2024-06-18T10:30:00Z'
+---
+```
+
+| Field         | Source in XML export | Description |
+| ------------- | -------------------- | ----------- |
+| `source/note` | `<generator>` + `<base>` | Human-readable import note (e.g. `Imported from MediaWiki 1.41.0 website @ https://…`) |
+| `source/url`  | `<base>` + page title | Direct link to that page on the wiki |
+| `source/date` | `<timestamp>` on the revision used | UTC date of the exported revision (ISO 8601) |
+
+Index pages under `indexes/` only include `title` and `tags` — they are generated locally, not imported from the wiki.
+
+Wiki templates render as Obsidian callouts in place — wherever the template appeared in the original wikitext:
 
 ```markdown
 > [!character]

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ If you find this script useful, please consider supporting me on Patreon:
 
 ## 📦 Requirements
 
-- Python 3.8+ (already installed — see **Installation** below for the rest)
-- [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it)
+> **⚠️ Tested Pandoc version: 3.9.0.2**
+>
+> Pandoc integration (including wikilink post-processing) is tested against **Pandoc 3.9.0.2**. Other versions may work, but Pandoc's Markdown output can change between releases — if your version differs, conversion results may not match what was tested here.
 
-  Pandoc integration (including wikilink post-processing) has been tested with **Pandoc 3.9.0.2**. Other versions may work, but Pandoc's Markdown output can change between releases.
+- Python 3.8+ (already installed — see **Installation** below for the rest)
+- [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it). Install **3.9.0.2** when possible (see callout above).
 
 Python dependencies are listed in `requirements.txt`. All packages use pinned versions (`~=`) for compatibility across environments. You are free to remove the version constraints and try the latest (or older) releases if you prefer — just keep in mind that unpinned installs may introduce breaking changes.
 
@@ -52,7 +54,11 @@ These steps assume **Python 3.8+ is already installed**. Clone or download this 
 
 ### 1. Install the Pandoc CLI (optional but recommended)
 
-`convert.py` uses Pandoc when available for wikitext-to-Markdown conversion and wikilink cleanup. Without it, the script still runs but leaves raw wikitext in place. You can also pass `--skip-pandoc` at runtime to bypass conversion even when Pandoc is installed. Install the CLI once for your operating system:
+`convert.py` uses Pandoc when available for wikitext-to-Markdown conversion and wikilink cleanup. Without it, the script still runs but leaves raw wikitext in place. You can also pass `--skip-pandoc` at runtime to bypass conversion even when Pandoc is installed.
+
+**Use Pandoc 3.9.0.2** — the version this project is tested against (see **Requirements**). Package managers often ship older releases; download the matching build from the [Pandoc install page](https://pandoc.org/installing.html) if needed.
+
+Install the CLI once for your operating system:
 
 > **Using Conda?** You can install Pandoc with `conda install -c conda-forge pandoc` inside your environment — see **Option B — Conda** below and skip this step.
 
@@ -221,10 +227,11 @@ With your environment activated:
 python convert.py --help
 ```
 
-You should see the script's help text. If you installed Pandoc, also check:
+You should see the script's help text. If you installed Pandoc, confirm the version matches **3.9.0.2** (the tested version):
 
 ```bash
 pandoc --version
+# Expected first line: pandoc 3.9.0.2
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vaul
 - 🔗 Converts internal links to Obsidian-safe `[[Wikilinks]]` via Pandoc post-processing
 - 📚 Automatically generates tag-based index files under `indexes/` (e.g. `Index Characters.md`)
 - 🐢 Uses Pandoc for wikitext-to-Markdown conversion when available (recommended; falls back to raw wikitext on failure)
-- ⏭️ Optional `--skip-pandoc` flag to bypass Pandoc conversion entirely and keep raw wikitext
+- ⏭️ Optional `--pandoc-skip` flag to bypass Pandoc conversion entirely and keep raw wikitext
+- 📝 Optional `--pandoc-plain-markdown` flag to preserve raw HTML via Pandoc's `raw_attribute` writer (see below)
 - 🔐 Optional `--cookies` flag for authenticated wikis (private wikis, login-required image downloads)
 - 🔍 Verbose mode for detailed output and easier troubleshooting
 
@@ -36,7 +37,7 @@ If you find this script useful, please consider supporting me on Patreon:
 > Pandoc integration (including wikilink post-processing) is tested against **Pandoc 3.9.0.2**. Other versions may work, but Pandoc's Markdown output can change between releases — if your version differs, conversion results may not match what was tested here.
 
 - Python 3.8+ (already installed — see **Installation** below for the rest)
-- [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it). Install **3.9.0.2** when possible (see callout above).
+- [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--pandoc-skip` to skip it). Install **3.9.0.2** when possible (see callout above).
 
 Python dependencies are listed in `requirements.txt`. All packages use pinned versions (`~=`) for compatibility across environments. You are free to remove the version constraints and try the latest (or older) releases if you prefer — just keep in mind that unpinned installs may introduce breaking changes.
 
@@ -53,7 +54,7 @@ These steps assume **Python 3.8+ is already installed**. Clone or download this 
 
 ### 1. Install the Pandoc CLI (optional but recommended)
 
-`convert.py` uses Pandoc when available for wikitext-to-Markdown conversion and wikilink cleanup. Without it, the script still runs but leaves raw wikitext in place. You can also pass `--skip-pandoc` at runtime to bypass conversion even when Pandoc is installed.
+`convert.py` uses Pandoc when available for wikitext-to-Markdown conversion and wikilink cleanup. Without it, the script still runs but leaves raw wikitext in place. You can also pass `--pandoc-skip` at runtime to bypass conversion even when Pandoc is installed.
 
 **Use Pandoc 3.9.0.2** — the version this project is tested against (see **Requirements**). Package managers often ship older releases; download the matching build from the [Pandoc install page](https://pandoc.org/installing.html) if needed.
 
@@ -295,25 +296,50 @@ See [Help:Export](https://www.mediawiki.org/wiki/Help:Export) and [Parameters to
 ## 🚀 Usage
 
 ```bash
-python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--skip-pandoc] [--verbose] [--cookies COOKIES]
+python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--pandoc-skip] [--pandoc-plain-markdown] [--verbose] [--cookies COOKIES]
 ```
 
-| Argument           | Description                                                                 |
-| ------------------ | --------------------------------------------------------------------------- |
-| `INPUT_XML`        | Path to your MediaWiki XML dump                                             |
-| `OUTPUT_DIR`       | Optional output folder (default: `obsidian_vault/`)                          |
-| `--skip-redirects` | Ignore redirect pages                                                       |
-| `--skip-pandoc`    | Skip Pandoc conversion and wikilink cleanup, even if Pandoc is installed     |
-| `--verbose`        | Enable verbose logging (disables progress bar)                              |
-| `--cookies`        | Cookie header for authenticated API/image requests (see below)              |
+| Argument                  | Description                                                                 |
+| ------------------------- | --------------------------------------------------------------------------- |
+| `INPUT_XML`               | Path to your MediaWiki XML dump                                             |
+| `OUTPUT_DIR`              | Optional output folder (default: `obsidian_vault/`)                          |
+| `--skip-redirects`        | Ignore redirect pages                                                       |
+| `--pandoc-skip`           | Skip Pandoc conversion and wikilink cleanup, even if Pandoc is installed     |
+| `--pandoc-plain-markdown` | Use Pandoc `--to=markdown` instead of the default `--to=markdown-raw_attribute` |
+| `--verbose`               | Enable verbose logging (disables progress bar)                              |
+| `--cookies`               | Cookie header for authenticated API/image requests (see below)              |
 
-### Skipping Pandoc (`--skip-pandoc`)
+### Skipping Pandoc (`--pandoc-skip`)
 
 Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, infobox callouts, images, and YAML frontmatter (title and tags) are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
 
 ```bash
-python convert.py wiki-dump.xml --skip-pandoc
+python convert.py wiki-dump.xml --pandoc-skip
 ```
+
+### Pandoc output format (`--pandoc-plain-markdown`)
+
+By default, the script calls Pandoc with `--to=markdown-raw_attribute`. In Pandoc's format syntax, the `-raw_attribute` suffix **disables** the [`raw_attribute` extension](https://pandoc.org/MANUAL.html#extension-raw_attribute) on the Markdown writer. That produces cleaner output for most Obsidian vaults — wikilinks, headings, and standard Markdown structures convert normally, and you avoid `{=html}` fenced code blocks in your notes.
+
+However, disabling `raw_attribute` can drop or reshape HTML that MediaWiki pages often rely on. Pandoc only has limited native Markdown syntax for complex markup (styled tables, nested `<div>`/`<span>` wrappers, figures with captions, inline HTML with attributes, etc.). When `raw_attribute` is off, Pandoc tends to:
+
+- **Convert** HTML it understands into Markdown or Pandoc fenced divs (`::: {.class}`), which can strip classes, inline styles, and other attributes ([discussion #9318](https://github.com/jgm/pandoc/discussions/9318))
+- **Emit bare HTML** only where the [`raw_html`](https://pandoc.org/MANUAL.html#extension-raw_html) extension still allows it, rather than wrapping content in explicit `{=html}` passthrough blocks
+- **Lose content** that has no Markdown equivalent and cannot be represented as plain HTML — for example, HTML comments and some block structures disappear when both `raw_attribute` and `raw_html` are disabled ([discussion #9324](https://github.com/jgm/pandoc/discussions/9324))
+
+Since Pandoc 3.2, the Markdown writer also prefers bare HTML over `{=html}` raw-attribute syntax when `raw_html` is enabled, because the two forms are equivalent in Pandoc's internal representation ([issue #10213](https://github.com/jgm/pandoc/issues/10213)). That makes round-tripping through Pandoc again less predictable, but it does not change the core trade-off: **without `raw_attribute`, you get tidier Markdown at the cost of less faithful HTML preservation.**
+
+Pass `--pandoc-plain-markdown` to use `--to=markdown` instead (with `raw_attribute` enabled). Pandoc will then wrap unrepresentable HTML in explicit `{=html}` fenced blocks and inline spans, preserving the original markup for manual cleanup or downstream tools that understand Pandoc's raw-attribute syntax. This is useful when your wiki dump contains heavy HTML formatting, custom templates rendered as HTML, or structures you need to keep intact even if Obsidian will not render them perfectly out of the box.
+
+```bash
+# Default — cleaner Markdown, may simplify or remove some HTML
+python convert.py wiki-dump.xml
+
+# Preserve raw HTML in Pandoc {=html} blocks
+python convert.py wiki-dump.xml --pandoc-plain-markdown
+```
+
+> **Tip:** If converted pages look fine in Obsidian, stick with the default. If you notice missing tables, stripped inline styles, or lost template HTML, try `--pandoc-plain-markdown` and review the output — you may need to clean up `{=html}` blocks manually afterward.
 
 ### Authenticated wikis (`--cookies`)
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vaul
 - 🏷️ Extracts and normalizes categories as `tags`
 - 📦 Converts infoboxes into YAML frontmatter (including images)
 - 🔧 Infers tags from infobox types using noun inflection
-- 🖼️ Downloads and embeds images as `![[images/Filename]]`
-- 🔗 Converts internal links to `[[Wikilinks]]`
+- 🖼️ Downloads and embeds images as `![[images/Filename]]` (supports `File:`, `Image:`, and `Media:` links)
+- 🔗 Converts internal links to Obsidian-safe `[[Wikilinks]]` via Pandoc post-processing
 - 📚 Automatically generates tag-based index files under `_indexes/`
-- 🐢 Supports optional Pandoc for better Markdown rendering
+- 🐢 Uses Pandoc for wikitext-to-Markdown conversion when available (recommended; falls back to raw wikitext on failure)
+- ⏭️ Optional `--skip-pandoc` flag to bypass Pandoc conversion entirely and keep raw wikitext
+- 🔐 Optional `--cookies` flag for authenticated wikis (private wikis, login-required image downloads)
 - 🔍 Verbose mode for detailed output and easier troubleshooting
 
 ## Support
@@ -29,33 +31,296 @@ If you find this script useful, please consider supporting me on Patreon:
 
 ## 📦 Requirements
 
-- Python 3.8+
-- [`pandoc`](https://pandoc.org/) (optional, but recommended for better Markdown conversion)
+- Python 3.8+ (already installed — see **Installation** below for the rest)
+- [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it)
 
-Install Python dependencies with:
+Python dependencies are listed in `requirements.txt`. All packages use pinned versions (`~=`) for compatibility across environments. You are free to remove the version constraints and try the latest (or older) releases if you prefer — just keep in mind that unpinned installs may introduce breaking changes.
+
+| Package            | Purpose                                |
+| ------------------ | -------------------------------------- |
+| `mwparserfromhell` | Parse and manipulate wikitext          |
+| `requests`         | Download images from the wiki API      |
+| `pyyaml`           | Generate YAML frontmatter              |
+| `tqdm`             | Progress bar during conversion         |
+| `inflect`          | Infer tags from infobox template names |
+
+## 🛠️ Installation
+
+These steps assume **Python 3.8+ is already installed**. Clone or download this repository, then open a terminal in the project folder (`mediawiki-to-markdown`).
+
+### 1. Install the Pandoc CLI (optional but recommended)
+
+`convert.py` uses Pandoc when available for wikitext-to-Markdown conversion and wikilink cleanup. Without it, the script still runs but leaves raw wikitext in place. You can also pass `--skip-pandoc` at runtime to bypass conversion even when Pandoc is installed. Install the CLI once for your operating system:
+
+> **Using Conda?** You can install Pandoc with `conda install -c conda-forge pandoc` inside your environment — see **Option B — Conda** below and skip this step.
+
+<details>
+<summary><strong>macOS</strong></summary>
+
+With [Homebrew](https://brew.sh/):
 
 ```bash
+brew install pandoc
+```
+
+Or download the macOS package from the [Pandoc install page](https://pandoc.org/installing.html).
+
+Verify:
+
+```bash
+pandoc --version
+```
+
+</details>
+
+<details>
+<summary><strong>Linux</strong></summary>
+
+**Debian / Ubuntu:**
+
+```bash
+sudo apt update
+sudo apt install pandoc
+```
+
+**Fedora:**
+
+```bash
+sudo dnf install pandoc
+```
+
+**Arch Linux:**
+
+```bash
+sudo pacman -S pandoc
+```
+
+Or use your distribution's package manager, or the [official Linux tarball](https://pandoc.org/installing.html).
+
+Verify:
+
+```bash
+pandoc --version
+```
+
+</details>
+
+<details>
+<summary><strong>Windows</strong></summary>
+
+Pick one of these options:
+
+**winget** (Windows 10/11):
+
+```powershell
+winget install JohnMacFarlane.Pandoc
+```
+
+**Chocolatey:**
+
+```powershell
+choco install pandoc
+```
+
+**Installer:** download the `.msi` from the [Pandoc install page](https://pandoc.org/installing.html) and run it. Restart your terminal afterward so `PATH` updates.
+
+Verify in **Command Prompt** or **PowerShell**:
+
+```powershell
+pandoc --version
+```
+
+</details>
+
+### 2. Install Python dependencies
+
+Choose **venv** (built into Python) or **Conda** (if you already use it).
+
+#### Option A — venv (recommended)
+
+<details>
+<summary><strong>macOS / Linux</strong></summary>
+
+```bash
+cd mediawiki-to-markdown
+
+python3 -m venv .venv
+source .venv/bin/activate
+
 pip install -r requirements.txt
 ```
+
+To deactivate later: `deactivate`
+
+</details>
+
+<details>
+<summary><strong>Windows (Command Prompt)</strong></summary>
+
+```bat
+cd mediawiki-to-markdown
+
+python -m venv .venv
+.venv\Scripts\activate.bat
+
+pip install -r requirements.txt
+```
+
+To deactivate later: `deactivate`
+
+</details>
+
+<details>
+<summary><strong>Windows (PowerShell)</strong></summary>
+
+```powershell
+cd mediawiki-to-markdown
+
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+
+pip install -r requirements.txt
+```
+
+If activation is blocked by execution policy, run once (as Administrator):
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+To deactivate later: `deactivate`
+
+</details>
+
+#### Option B — Conda
+
+Works the same on macOS, Linux, and Windows. Conda can install Pandoc alongside your Python dependencies in one environment:
+
+```bash
+cd mediawiki-to-markdown
+
+conda create -n mediawiki-md python=3.8
+conda activate mediawiki-md
+
+conda install -c conda-forge pandoc
+
+pip install -r requirements.txt
+```
+
+To deactivate later: `conda deactivate`
+
+> **Tip:** If you install Pandoc here, you can skip step 1 above.
+
+### 3. Verify the setup
+
+With your environment activated:
+
+```bash
+python convert.py --help
+```
+
+You should see the script's help text. If you installed Pandoc, also check:
+
+```bash
+pandoc --version
+```
+
+---
+
+## 📥 Creating the input XML file
+
+`convert.py` expects a MediaWiki XML export — the same format produced by [Special:Export](https://www.mediawiki.org/wiki/Special:Export) or `dumpBackup.php`. The file must include a `<base>` URL in `<siteinfo>` so the script can resolve image downloads.
+
+### CLI (preferred)
+
+If you have shell access to the MediaWiki server, use the maintenance script. This is the simplest and most reliable option for full or partial exports.
+
+From the wiki root directory:
+
+```bash
+# Current revision of every page
+php maintenance/run.php dumpBackup --current > wiki-dump.xml
+
+# Full revision history
+php maintenance/run.php dumpBackup --full > wiki-dump-full.xml
+
+# Specific namespaces only (0 = main, 10 = Template, 14 = Category, etc.)
+php maintenance/run.php dumpBackup --current --namespaces 0,10,14 > partial-dump.xml
+
+# Pages listed in a text file (one title per line)
+php maintenance/run.php dumpBackup --current --pagelist pages.txt > selected.xml
+```
+
+On older MediaWiki installations you may need to run the script directly from the `maintenance/` folder:
+
+```bash
+cd maintenance
+php dumpBackup.php --current > ../wiki-dump.xml
+```
+
+See the [dumpBackup.php manual](https://www.mediawiki.org/wiki/Manual:DumpBackup.php) for all options.
+
+### Web (Special:Export)
+
+Use this when you do not have server access, or only need a small set of pages.
+
+1. Open `Special:Export` on your wiki (e.g. `https://your-wiki.example/wiki/Special:Export`).
+2. Enter page titles — one per line — in the text box. For a single page you can also visit `Special:Export/Page_Title` directly.
+3. Optionally check **Include templates** so transcluded templates are exported too.
+4. Optionally check **Export all revisions** to include full history (limited to 100 revisions per page via the web UI).
+5. Click **Export** and save the downloaded XML file.
+
+For scripted exports over HTTP, you can POST to `Special:Export` with curl:
+
+```bash
+curl -d "pages=Main_Page&pages=Another_Page&action=submit" \
+  "https://your-wiki.example/wiki/Special:Export" \
+  -o wiki-export.xml
+```
+
+See [Help:Export](https://www.mediawiki.org/wiki/Help:Export) and [Parameters to Special:Export](https://www.mediawiki.org/wiki/Manual:Parameters_to_Special:Export) for details.
+
+> **Tip:** If your export does not include templates, pages that rely on them may not render correctly after conversion. Include templates in the export when possible.
+
+---
 
 ## 🚀 Usage
 
 ```bash
-python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--verbose]
+python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--skip-pandoc] [--verbose] [--cookies COOKIES]
 ```
 
-| Argument           | Description                                         |
-| ------------------ | --------------------------------------------------- |
-| `INPUT_XML`        | Path to your MediaWiki XML dump                     |
-| `OUTPUT_DIR`       | Optional output folder (default: `obsidian_vault/`) |
-| `--skip-redirects` | Ignore redirect pages                               |
-| `--verbose`        | Enable verbose logging (disables progress bar)      |
+| Argument           | Description                                                                 |
+| ------------------ | --------------------------------------------------------------------------- |
+| `INPUT_XML`        | Path to your MediaWiki XML dump                                             |
+| `OUTPUT_DIR`       | Optional output folder (default: `obsidian_vault/`)                          |
+| `--skip-redirects` | Ignore redirect pages                                                       |
+| `--skip-pandoc`    | Skip Pandoc conversion and wikilink cleanup, even if Pandoc is installed     |
+| `--verbose`        | Enable verbose logging (disables progress bar)                              |
+| `--cookies`        | Cookie header for authenticated API/image requests (see below)              |
 
+### Skipping Pandoc (`--skip-pandoc`)
+
+Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, infoboxes, images, and YAML frontmatter are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
+
+```bash
+python convert.py wiki-dump.xml --skip-pandoc
+```
+
+### Authenticated wikis (`--cookies`)
+
+If the wiki requires login to access images or the API, copy the `Cookie` header from an authenticated browser session (e.g. Developer Tools → Network → any request → Request Headers) and pass it to the script:
+
+```bash
+python convert.py wiki-dump.xml --cookies "sessionid=abc123; csrftoken=xyz789"
+```
+
+---
 
 ## 🗂️ Output Structure
 
 ```text
-chronicler_vault/
+obsidian_vault/
 ├── _indexes/
 │   ├── _people.md
 │   ├── _locations.md

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--pandoc-skip] [--p
 
 ### Skipping Pandoc (`--pandoc-skip`)
 
-Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, infobox callouts, images, and YAML frontmatter (title and tags) are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
+Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, template callouts, images, and YAML frontmatter (title and tags) are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
 
 ```bash
 python convert.py wiki-dump.xml --pandoc-skip

--- a/convert.py
+++ b/convert.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Union
+from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 import xml.etree.ElementTree as ET
 
 import mwparserfromhell
@@ -78,18 +79,70 @@ tag_to_pages: DefaultDict[str, List[str]] = defaultdict(list)
 filename_counts: DefaultDict[str, int] = defaultdict(int)
 
 WIKI_URL: Optional[str] = None
+WIKI_BASE_URL: Optional[str] = None
+WIKI_GENERATOR: Optional[str] = None
 
 
-def extract_wiki_url(tree: ET.ElementTree) -> str:
-    """Extract the wiki base URL (scheme + host) from a MediaWiki XML export."""
+def extract_wiki_url(tree: ET.ElementTree) -> Tuple[str, str, str]:
+    """Extract wiki host URL, full base page URL, and generator from a MediaWiki XML export."""
     ns = {"ns": NS}
-    base_elem = tree.find(".//ns:siteinfo/ns:base", ns)
+    siteinfo = tree.find(".//ns:siteinfo", ns)
+    if siteinfo is None:
+        raise ValueError("Could not find <siteinfo> in XML export.")
+
+    generator_elem = siteinfo.find("ns:generator", ns)
+    generator = "MediaWiki"
+    if generator_elem is not None and generator_elem.text:
+        generator = generator_elem.text.strip()
+
+    base_elem = siteinfo.find("ns:base", ns)
     if base_elem is not None and base_elem.text:
         base_url = base_elem.text.strip()
         match = re.match(r"(https?://[^/]+)/", base_url)
         if match:
-            return match.group(1)
+            return match.group(1), base_url, generator
     raise ValueError("Could not extract wiki domain from <base> tag.")
+
+
+def build_mediawiki_page_url(page_title: str) -> str:
+    """Build a canonical wiki URL for ``page_title`` using the export ``<base>`` URL."""
+    if not WIKI_BASE_URL:
+        raise ValueError("Wiki base URL not set.")
+
+    wiki_title = page_title.replace(" ", "_")
+    parsed = urlparse(WIKI_BASE_URL)
+
+    if parsed.query and "title=" in parsed.query.lower():
+        query = parse_qs(parsed.query, keep_blank_values=True)
+        query["title"] = [wiki_title]
+        return urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path,
+                parsed.params,
+                urlencode(query, doseq=True),
+                parsed.fragment,
+            )
+        )
+
+    path_dir, _, _ = parsed.path.rpartition("/")
+    encoded_title = quote(wiki_title, safe=":/")
+    new_path = f"{path_dir}/{encoded_title}" if path_dir else f"/{encoded_title}"
+    return urlunparse(
+        (parsed.scheme, parsed.netloc, new_path, parsed.params, parsed.query, parsed.fragment)
+    )
+
+
+def build_source_fields(page_title: str, revision_date: Optional[str] = None) -> Dict[str, Any]:
+    """Build YAML front matter fields describing the original MediaWiki source."""
+    fields = {
+        "source/note": f"Imported from {WIKI_GENERATOR} website @ {WIKI_URL}",
+        "source/url": build_mediawiki_page_url(page_title),
+    }
+    if revision_date:
+        fields["source/date"] = revision_date
+    return fields
 
 
 def clean_filename(title: str) -> str:
@@ -389,7 +442,9 @@ def convert_with_pandoc(text: str, title: str = "") -> str:
         return text
 
 
-def prepare_wikitext(raw_text: str, title: str) -> Tuple[str, str, List[str]]:
+def prepare_wikitext(
+    raw_text: str, title: str, revision_date: Optional[str] = None
+) -> Tuple[str, str, List[str]]:
     """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
 
     Processes categories and images, transforms templates to callouts, builds an Obsidian YAML
@@ -408,8 +463,11 @@ def prepare_wikitext(raw_text: str, title: str) -> Tuple[str, str, List[str]]:
     wikicode = transform_templates_to_callouts(wikicode)
 
     cleaned_text = str(wikicode).strip()
+    page_title = title.strip()
     title = clean_filename(title)
-    yaml_header = build_yaml_header(title, tags)
+    yaml_header = build_yaml_header(
+        title, tags, extra_fields=build_source_fields(page_title, revision_date)
+    )
 
     # Track tags for index
     for tag in tags:
@@ -477,7 +535,13 @@ def convert_pages(tree: ET.ElementTree) -> None:
                 # Because template invocations are converted to callouts in article wikitext
                 raw_text += wrap_original_mediawiki_source(text_elem.text)
             raw_text += text_elem.text
-            yaml_str, wikitext, tags = prepare_wikitext(raw_text, title)
+            timestamp_elem = latest_revision.find(TAG("timestamp"))
+            revision_date = (
+                timestamp_elem.text.strip()
+                if timestamp_elem is not None and timestamp_elem.text
+                else None
+            )
+            yaml_str, wikitext, tags = prepare_wikitext(raw_text, title, revision_date)
 
             if not PANDOC_SKIP and PANDOC_AVAILABLE:
                 wikitext = convert_with_pandoc(wikitext, title)
@@ -535,8 +599,8 @@ def main() -> None:
         return
 
     try:
-        global WIKI_URL
-        WIKI_URL = extract_wiki_url(tree)
+        global WIKI_URL, WIKI_BASE_URL, WIKI_GENERATOR
+        WIKI_URL, WIKI_BASE_URL, WIKI_GENERATOR = extract_wiki_url(tree)
     except ValueError as e:
         logging.error(f"‼️ {e}")
         return

--- a/convert.py
+++ b/convert.py
@@ -20,14 +20,6 @@ p = inflect.engine()
 NS = "http://www.mediawiki.org/xml/export-0.11/"
 IMAGE_DIR = "images"
 
-# Pre-compiled regex patterns
-INVALID_FILENAME_CHARS = re.compile(r'[\\/*?:"<>|]')
-HEADING_ID_REGEX = re.compile(r'^(#{1,6} .+?)\s*\{\#.*?\}', re.MULTILINE)
-WIKILINK_REGEX = re.compile(r'\[\[(.*?)\]\]', re.DOTALL)
-PANDOC_LINK_REGEX = re.compile(
-    r'\[([^\]]+)\]\(((?:[^\(\)]+|\([^\)]*\))+)(?:\s+"wikilink")?\)'
-)
-
 def TAG(t):
     return f"{{{NS}}}{t}"
 
@@ -72,25 +64,10 @@ def extract_wiki_url(tree):
 
 def clean_filename(title):
     """Convert to safe filename with underscores"""
-    return INVALID_FILENAME_CHARS.sub('_', title.strip())
+    return re.compile(r'[\\/*?:"<>|{}]').sub('_', title.strip())
 
 def normalize_tag(tag):
     return tag.replace(" ", "_").lower()
-
-def display_title(title):
-    """Convert to human-readable title with spaces"""
-    return title.replace('_', ' ')
-
-def clean_wikilink(link_content):
-    """Centralized wikilink cleaning"""
-    if '|' in link_content:
-        target, alias = link_content.split('|', 1)
-        return f"[[{target.replace('_', ' ')}|{alias}]]"
-    return f"[[{link_content.replace('_', ' ')}]]"
-
-def fix_wikilink_spacing(text):
-    """Convert underscores to spaces in wikilinks using centralized cleaner"""
-    return WIKILINK_REGEX.sub(lambda m: clean_wikilink(m.group(1)), text)
 
 def extract_categories(wikicode):
     categories = []
@@ -199,7 +176,7 @@ def extract_infobox(wikicode):
         key = param.name.strip().replace(":", "").lower()
         val = param.value.strip()
 
-        wikilinks = WIKILINK_REGEX.findall(val)
+        wikilinks = re.compile(r'\[\[(.*?)\]\]', re.DOTALL).findall(val)
         if wikilinks:
             parts = []
             remaining = val
@@ -236,33 +213,40 @@ def sanitize_for_yaml(obj):
         return str(obj)
 
 def extract_yaml_header(title, tags, extra_fields=None):
-    header = {
-        'title': display_title(title),
-        'tags': tags
-    }
+    header = {'title': title, 'tags': tags}
     if extra_fields:
         header.update(sanitize_for_yaml(extra_fields))
 
     return f"---\n{yaml.safe_dump(header, sort_keys=False)}---\n"
 
 def clean_heading_ids(md_text):
-    return HEADING_ID_REGEX.sub(r'\1', md_text)
+    return re.compile(r'^(#{1,6} .+?)\s*\{\#.*?\}', re.MULTILINE).sub(r'\1', md_text)
 
-def extract_links_from_pandoc(md_text):
-    def replacer(match):
-        text = match.group(1).strip()
-        target = match.group(2).replace(' "wikilink"', '').strip()
 
-        if target.startswith(('http://', 'https://', 'mailto:')):
-            return match.group(0)
-
-        clean_target = display_title(target)
-        # Only include alias if it's actually different
-        if text == clean_target:
-            return f"[[{clean_target}]]"
+def fix_links_from_pandoc(md_text):
+    def replace_wikilinks_no_files(match: re.Match):
+        cleaned_filename = clean_filename(match.group(2).strip().replace('_', ' '))
+        text = match.group(3).strip()
+        if cleaned_filename == text:
+            return f'[[{cleaned_filename}]]'
         else:
-            return f"[[{clean_target}|{text}]]"
-    return PANDOC_LINK_REGEX.sub(replacer, md_text)
+            return f'[[{cleaned_filename}|{text}]]'
+
+    pandoc_wikilink_no_files_regex = re.compile(r'(?<!!)\[([^]]+)\]\(([^ ]+) "(.+?)"\)({[^}]+})?')
+    md_text_link_no_files_fixed = pandoc_wikilink_no_files_regex.sub(
+        replace_wikilinks_no_files, md_text
+    )
+
+    def replace_wikilink_inline_files(match: re.Match):
+        text = match.group(3).strip()
+        return f'![[{text}]]'
+
+    pandoc_wikilink_inline_files_regex = re.compile(r'\\*!\[([^]]+)\]\(([^ ]+) "(.+?)"\)({[^}]+})?')
+    md_text_link_files_fixed = pandoc_wikilink_inline_files_regex.sub(
+        replace_wikilink_inline_files, md_text_link_no_files_fixed
+    )
+    return md_text_link_files_fixed
+
 
 def clean_residual_wikilink_artifacts(md_text):
     return md_text.replace(' "wikilink"', '')
@@ -272,9 +256,8 @@ def fix_image_links(md):
 
 def cleanup_markdown(md):
     md = clean_heading_ids(md)
-    md = extract_links_from_pandoc(md)
+    md = fix_links_from_pandoc(md)
     md = clean_residual_wikilink_artifacts(md)
-    md = fix_wikilink_spacing(md)
     md = fix_image_links(md)
     return md
 
@@ -296,11 +279,23 @@ def convert_with_pandoc(text, title=""):
         return text
 
 def clean_and_convert_text(raw_text, title):
+    """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
+
+    Extracts categories, images, and infobox data; builds an Obsidian YAML
+    front matter header; and records tags in the global tag index.
+
+    Note: Tags will become a file and a property, weird characters will break linking,
+    cleaning for good filenames with `clean_filename()`
+
+    Returns (yaml_header, cleaned_wikitext, tags).
+    """
     text = unescape(raw_text)
     wikicode = mwparserfromhell.parse(text)
     wikicode, tags = extract_categories(wikicode)
     wikicode = extract_images(wikicode)
     wikicode, infobox_data = extract_infobox(wikicode)
+
+    tags = [clean_filename(tag) for tag in tags]
 
     # Conditionally infer tag
     if infobox_data.get('infobox'):
@@ -315,6 +310,7 @@ def clean_and_convert_text(raw_text, title):
             tags.append(inferred_tag)
 
     cleaned_text = str(wikicode).strip()
+    title = clean_filename(title)
     yaml_header = extract_yaml_header(title, tags, infobox_data)
 
     # Track tags for index
@@ -376,14 +372,24 @@ def convert_pages(tree):
     logging.info("✅ Main articles converted")
 
 def create_tag_indexes():
+    """Write Obsidian index pages for each collected tag.
+
+    Uses the global tag_to_pages map populated during conversion(`clean_and_convert_text()`)
+    to emit one markdown file per tag under _indexes/, each with YAML front matter and
+    wikilinks to every page in that tag.
+
+    Note: Tags and page titles become filenames and wikilinks; weird characters
+    will break linking, so both are cleaned with `clean_filename()`.
+    """
     index_dir = os.path.join(OUTPUT_DIR, "_indexes")
     os.makedirs(index_dir, exist_ok=True)
     for tag, pages in tag_to_pages.items():
-        display_tag = display_title(tag)
+        tag = clean_filename(tag)
+        display_tag = tag
         yaml_header = extract_yaml_header(f"Index: {display_tag}", tag)
         lines = [f"# {display_tag.title()} Index"]
         for page in sorted(pages):
-            display_page = display_title(page)
+            display_page = clean_filename(page)
             lines.append(f"- [[{display_page}]]")
         content = yaml_header + "\n".join(lines)
         with open(os.path.join(index_dir, f"_{tag}.md"), "w", encoding="utf-8") as f:

--- a/convert.py
+++ b/convert.py
@@ -1,32 +1,36 @@
+import argparse
+from collections import defaultdict
+import copy
+from html import unescape
+import logging
 import os
 import re
 import shutil
 import subprocess
-import xml.etree.ElementTree as ET
-from html import unescape
-from collections import defaultdict
-import mwparserfromhell
 import sys
-import json
-import requests
-import yaml
-import argparse
-import inflect
-import logging
-from tqdm import tqdm
+from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Union
+import xml.etree.ElementTree as ET
 
-p = inflect.engine()
+import inflect
+import mwparserfromhell
+from mwparserfromhell.nodes import Template, Wikilink
+from mwparserfromhell.wikicode import Wikicode
+import requests
+from tqdm import tqdm
+import yaml
+
+p: inflect.engine = inflect.engine()
 
 # Constants
 NS = "http://www.mediawiki.org/xml/export-0.11/"
 IMAGE_DIR = "images"
 
 
-def TAG(t):
+def TAG(t: str) -> str:
     return f"{{{NS}}}{t}"
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Convert MediaWiki XML to Obsidian Vault")
     parser.add_argument("input_xml", help="Input XML file")
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
@@ -42,7 +46,7 @@ def parse_args():
     return parser.parse_args()
 
 
-args = parse_args()
+args: argparse.Namespace = parse_args()
 
 logging.basicConfig(
     level=logging.DEBUG if args.verbose else logging.INFO,
@@ -50,12 +54,12 @@ logging.basicConfig(
     handlers=[logging.StreamHandler(sys.stdout)],
 )
 
-INPUT_XML = args.input_xml
-OUTPUT_DIR = args.output_dir
-SKIP_REDIRECTS = args.skip_redirects
-SKIP_PANDOC = args.skip_pandoc
-COOKIES = args.cookies
-PANDOC_AVAILABLE = shutil.which("pandoc") is not None
+INPUT_XML: str = args.input_xml
+OUTPUT_DIR: str = args.output_dir
+SKIP_REDIRECTS: bool = args.skip_redirects
+SKIP_PANDOC: bool = args.skip_pandoc
+COOKIES: Optional[str] = args.cookies
+PANDOC_AVAILABLE: bool = shutil.which("pandoc") is not None
 
 if not SKIP_PANDOC and not PANDOC_AVAILABLE:
     logging.warning(
@@ -65,50 +69,51 @@ if not SKIP_PANDOC and not PANDOC_AVAILABLE:
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-tag_to_pages = defaultdict(list)
-filename_counts = defaultdict(int)
+tag_to_pages: DefaultDict[str, List[str]] = defaultdict(list)
+filename_counts: DefaultDict[str, int] = defaultdict(int)
 
-WIKI_URL = None
+WIKI_URL: Optional[str] = None
 
 
-def extract_wiki_url(tree):
-    global WIKI_URL
+def extract_wiki_url(tree: ET.ElementTree) -> str:
     ns = {"ns": NS}
     base_elem = tree.find(".//ns:siteinfo/ns:base", ns)
     if base_elem is not None and base_elem.text:
         base_url = base_elem.text.strip()
-        WIKI_URL = re.match(r"(https?://[^/]+)/", base_url).group(1)
-        if WIKI_URL:
-            return
+        match = re.match(r"(https?://[^/]+)/", base_url)
+        if match:
+            return match.group(1)
     raise ValueError("Could not extract wiki domain from <base> tag.")
 
 
-def clean_filename(title):
+def clean_filename(title: str) -> str:
     """Convert to safe filename with underscores"""
     return re.compile(r'[\\/*?:"<>|{}]').sub('_', title.strip())
 
 
-def normalize_tag(tag):
-    return tag.replace(" ", "_").lower()
+def normalize_tag(tag: str) -> str:
+    return re.compile(r'[ \\/*?:"<>|{}]').sub('_', tag.strip())
 
 
-def extract_categories(wikicode):
+def process_categories(wikicode: Wikicode) -> Tuple[Wikicode, List[str]]:
+    wikicode = copy.deepcopy(wikicode)  # Copy to avoid external mutation
     categories = []
     for link in wikicode.ifilter_wikilinks():
         target = link.title.strip()
         if target.lower().startswith("category:"):
             cat = target[len("category:") :].strip()
             categories.append(normalize_tag(cat))
-            wikicode.remove(link)
+            wikicode.replace(link, f'[[Index {clean_filename(target[len("category:"):])}]]')
     return wikicode, categories
 
 
-def extract_images(wikicode):
+def embed_images(wikicode: Wikicode) -> Wikicode:
+    wikicode = copy.deepcopy(wikicode)  # Copy to avoid external mutation
     images = set()
     nodes = list(wikicode.nodes)  # make a list copy because we'll modify
 
     for i, node in enumerate(nodes):
-        if isinstance(node, mwparserfromhell.wikicode.Wikilink):
+        if isinstance(node, Wikilink):
             target = node.title.strip()
             if target.lower().startswith(("file:", "image:", "media:")):
                 image_name = target.split(":", 1)[1].strip()
@@ -124,7 +129,7 @@ def extract_images(wikicode):
     return wikicode
 
 
-def get_image_url(filename):
+def get_image_url(filename: str) -> Optional[str]:
     url = f"{WIKI_URL}/api.php"
     params = {
         "action": "query",
@@ -133,22 +138,21 @@ def get_image_url(filename):
         "titles": filename,
         "iiprop": "url",
     }
-    try:
-        resp = requests.get(
-            url, params=params, timeout=10, headers={"Cookie": COOKIES} if COOKIES else None
-        )
-        data = resp.json()
-        pages = data.get("query", {}).get("pages", {})
-        for page in pages.values():
-            ii = page.get("imageinfo")
-            if ii:
-                return ii[0]["url"]
-    except Exception as e:
-        logging.error(f"❌ Failed to get image URL for {filename}: {e}")
+    resp = requests.get(
+        url, params=params, timeout=10, headers={"Cookie": COOKIES} if COOKIES else None
+    )
+    if resp.headers.get('MediaWiki-API-Error') == 'readapidenied':
+        raise PermissionError("Access to the wiki needs an account, pass cookies to the CLI.")
+    data = resp.json()
+    pages = data.get("query", {}).get("pages", {})
+    for page in pages.values():
+        ii = page.get("imageinfo")
+        if ii:
+            return ii[0]["url"]
     return None
 
 
-def download_image(image_name):
+def download_image(image_name: str) -> Optional[str]:
     if not image_name:
         return None
 
@@ -158,9 +162,10 @@ def download_image(image_name):
         logging.debug(f"🖼️ Skipping download (already exists): {safe_name}")
         return safe_name
 
-    url = get_image_url(f"File:{image_name}")
-    if not url:
-        logging.warning(f"❌ Could not find URL for image: {image_name}")
+    try:
+        url = get_image_url(f"File:{image_name}")
+    except Exception as e:
+        logging.error(f"‼️ Could not find URL for image: {image_name}: {e}")
         return None
 
     try:
@@ -173,65 +178,79 @@ def download_image(image_name):
             logging.debug(f"📥 Downloaded image: {safe_name}")
             return safe_name
         else:
-            logging.error(f"❌ Failed to download image: {image_name} ({resp.status_code})")
+            logging.error(f"‼️ Failed to download image: {image_name} ({resp.status_code})")
             return None
     except Exception as e:
-        logging.error(f"❌ Error downloading {image_name}: {e}")
+        logging.error(f"‼️ Error downloading {image_name}: {e}")
         return None
 
 
-def extract_infobox(wikicode):
-    infobox_data = {}
-    infobox_template = None
+def infobox_to_dict(template: Template) -> Dict[str, Any]:
+    infobox_data: Dict[str, Any] = {}
 
-    for template in wikicode.filter_templates():
-        if template.name.strip():
-            infobox_template = template
-            break
-
-    if not infobox_template:
-        return wikicode, {}
-
-    raw_name = infobox_template.name.strip().lower()
+    raw_name = template.name.strip().lower()
     if raw_name.startswith("infobox_"):
-        infobox_type = raw_name[len("infobox_") :].replace(' ', '_').title()
+        infobox_type = raw_name[len("infobox_") :].replace(' ', '_')  # .title()
     else:
-        infobox_type = infobox_template.name
+        infobox_type = template.name
 
     infobox_data['infobox'] = infobox_type
 
-    for param in infobox_template.params:
+    for param in template.params:
         key = param.name.strip().replace(":", "").lower()
         val = param.value.strip()
+        infobox_data[key] = val
 
-        wikilinks = re.compile(r'\[\[(.*?)\]\]', re.DOTALL).findall(val)
-        if wikilinks:
-            parts = []
-            remaining = val
-            for link in wikilinks:
-                before, link_part, remaining = remaining.partition(f"[[{link}]]")
-                if before.strip():
-                    parts.append(before.strip())
-                parts.append(f"[[{link}]]")
-            if remaining.strip():
-                parts.append(remaining.strip())
-            infobox_data[key] = parts
-        else:
-            infobox_data[key] = val
+    return infobox_data
 
-    wikicode.remove(infobox_template)
 
-    # Extract the image from the infox and inline it at top of markdown
+def infobox_dict_to_callout(infobox_data: Dict[str, Any]) -> str:
+    callout_info = {
+        data: str(infobox_data[data]).replace('\n', '')
+        for data in infobox_data
+        if data not in ('infobox', 'image')  # These are treated differently
+    }
+
+    callout = ''
+    callout += f'\n> [!{infobox_data['infobox']}]' if infobox_data['infobox'] else '\n> [!NOTE]'
     if image_name := infobox_data.get('image'):
         image_name = image_name.strip()
         download_image(image_name)
-        embed = f"![[{IMAGE_DIR}/{image_name}]]\n\n"
-        wikicode.insert(0, embed)
+        callout += f'\n> - **image**: ![[{IMAGE_DIR}/{image_name}]]'
 
-    return wikicode, infobox_data
+    for data in callout_info:
+        callout += f'\n> - **{data}**: {callout_info[data]}'
+
+    return callout
 
 
-def sanitize_for_yaml(obj):
+def transform_infobox_to_callout(wikicode: Wikicode) -> Wikicode:
+    wikicode = copy.deepcopy(wikicode)  # Copy to avoid external mutation
+    if len(wikicode.filter_templates()) == 0:
+        return wikicode
+
+    while template_list := wikicode.filter_templates():
+        template = template_list[0]
+        infobox_dict = infobox_to_dict(template)
+        callout = infobox_dict_to_callout(infobox_dict)
+
+        use_pandoc = not SKIP_PANDOC and PANDOC_AVAILABLE
+        callout_to_insert = '\n'
+        if use_pandoc:
+            callout_to_insert += '\n<source lang="obsidian-callout-block">'
+            callout_to_insert += callout
+            callout_to_insert += '\n</source>'
+        else:
+            callout_to_insert += callout
+
+        callout_to_insert += '\n'
+
+        wikicode.replace(template, callout_to_insert)
+
+    return wikicode
+
+
+def sanitize_for_yaml(obj: Any) -> Any:
     if isinstance(obj, dict):
         return {sanitize_for_yaml(k): sanitize_for_yaml(v) for k, v in obj.items()}
     elif isinstance(obj, list):
@@ -242,7 +261,13 @@ def sanitize_for_yaml(obj):
         return str(obj)
 
 
-def extract_yaml_header(title, tags, extra_fields=None):
+def build_yaml_header(
+    title: str,
+    tags: Union[List[str], str],
+    extra_fields: Optional[Dict[str, Any]] = None,
+) -> str:
+    # Ensure tags are unique (if tags is a list), but preserve string if given
+    tags = list(dict.fromkeys([tags] if isinstance(tags, str) else tags))
     header = {'title': title, 'tags': tags}
     if extra_fields:
         header.update(sanitize_for_yaml(extra_fields))
@@ -250,12 +275,12 @@ def extract_yaml_header(title, tags, extra_fields=None):
     return f"---\n{yaml.safe_dump(header, sort_keys=False)}---\n"
 
 
-def clean_heading_ids(md_text):
+def clean_heading_ids(md_text: str) -> str:
     return re.compile(r'^(#{1,6} .+?)\s*\{\#.*?\}', re.MULTILINE).sub(r'\1', md_text)
 
 
-def fix_links_from_pandoc(md_text):
-    def replace_wikilinks_no_files(match: re.Match):
+def fix_links_from_pandoc(md_text: str) -> str:
+    def replace_wikilinks_no_files(match: re.Match) -> str:
         cleaned_filename = clean_filename(match.group(2).strip().replace('_', ' '))
         text = match.group(3).strip()
         if cleaned_filename == text:
@@ -268,7 +293,7 @@ def fix_links_from_pandoc(md_text):
         replace_wikilinks_no_files, md_text
     )
 
-    def replace_wikilink_inline_files(match: re.Match):
+    def replace_wikilink_inline_files(match: re.Match) -> str:
         text = match.group(3).strip()
         return f'![[{text}]]'
 
@@ -279,26 +304,51 @@ def fix_links_from_pandoc(md_text):
     return md_text_link_files_fixed
 
 
-def clean_residual_wikilink_artifacts(md_text):
+def clean_residual_wikilink_artifacts(md_text: str) -> str:
     return md_text.replace(' "wikilink"', '')
 
 
-def fix_image_links(md):
+def fix_image_links(md: str) -> str:
     return re.sub(r'\\(!\[\[)', r'\1', md)
 
 
-def cleanup_markdown(md):
+def remove_obsidian_callout_block(md_text: str) -> str:
+    """
+    Removes code blocks with language 'obsidian-callout-block' from the markdown text.
+
+    This function removes code blocks created as <source lang="obsidian-callout-block">
+    in the transform_infobox_to_callout function. The cleanup is only needed—and only
+    takes place—when Pandoc is used, because Pandoc preserves these fenced code blocks.
+
+    Args:
+        md_text (str): The markdown content.
+
+    Returns:
+        str: Markdown content with 'obsidian-callout-block' code blocks removed, leaving only their content.
+    """
+    # This regex finds fenced code blocks with lang 'obsidian-callout-block' and replaces the whole block
+    # (including the fences) with just the content inside the block.
+    return re.sub(
+        r'```\s*obsidian-callout-block\s*\n(.*?)```',
+        r'\1',
+        md_text,
+        flags=re.DOTALL,
+    )
+
+
+def cleanup_markdown(md: str) -> str:
     md = clean_heading_ids(md)
     md = fix_links_from_pandoc(md)
     md = clean_residual_wikilink_artifacts(md)
     md = fix_image_links(md)
+    md = remove_obsidian_callout_block(md)
     return md
 
 
-def convert_with_pandoc(text, title=""):
+def convert_with_pandoc(text: str, title: str = "") -> str:
     try:
         result = subprocess.run(
-            ['pandoc', '--from=mediawiki', '--to=markdown', '--wrap=none'],
+            ['pandoc', '--from=mediawiki', '--to=markdown-raw_attribute', '--wrap=none'],
             input=text.encode("utf-8"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -317,11 +367,11 @@ def convert_with_pandoc(text, title=""):
         return text
 
 
-def clean_and_convert_text(raw_text, title):
+def prepare_wikitext(raw_text: str, title: str) -> Tuple[str, str, List[str]]:
     """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
 
-    Extracts categories, images, and infobox data; builds an Obsidian YAML
-    front matter header; and records tags in the global tag index.
+    Processes categories and images, transforms infoboxes, builds an Obsidian YAML
+    front matter header, and records tags in the global tag index.
 
     Note: Tags will become a file and a property, weird characters will break linking,
     cleaning for good filenames with `clean_filename()`
@@ -330,27 +380,14 @@ def clean_and_convert_text(raw_text, title):
     """
     text = unescape(raw_text)
     wikicode = mwparserfromhell.parse(text)
-    wikicode, tags = extract_categories(wikicode)
-    wikicode = extract_images(wikicode)
-    wikicode, infobox_data = extract_infobox(wikicode)
+    wikicode, tags = process_categories(wikicode)
+    wikicode = embed_images(wikicode)
 
-    tags = [clean_filename(tag) for tag in tags]
-
-    # Conditionally infer tag
-    if infobox_data.get('infobox'):
-        infobox_name = str(infobox_data['infobox'])
-
-        if not p.singular_noun(infobox_name):
-            infobox_name = p.plural(infobox_name)
-
-        inferred_tag = normalize_tag(infobox_name)
-
-        if inferred_tag not in tags:
-            tags.append(inferred_tag)
+    wikicode = transform_infobox_to_callout(wikicode)
 
     cleaned_text = str(wikicode).strip()
     title = clean_filename(title)
-    yaml_header = extract_yaml_header(title, tags, infobox_data)
+    yaml_header = build_yaml_header(title, tags)
 
     # Track tags for index
     for tag in tags:
@@ -359,7 +396,13 @@ def clean_and_convert_text(raw_text, title):
     return yaml_header, cleaned_text, tags
 
 
-def convert_pages(tree):
+def wrap_original_mediawiki_source(mediawiki_text: str) -> str:
+    """Wrap raw MediaWiki wikitext in a preserved source block."""
+    escaped_text = mediawiki_text.replace('</source>', '&lt;/source&gt;')
+    return '\n<source lang="original-mediawiki-source">' f'{escaped_text}' '\n</source>' '\n\n'
+
+
+def convert_pages(tree: ET.ElementTree) -> None:
     ns = {"ns": NS}
     total_pages = len(tree.findall(".//ns:page", {"ns": NS}))
 
@@ -404,8 +447,15 @@ def convert_pages(tree):
                 pbar.update(1)
                 continue
 
-            raw_text = text_elem.text
-            yaml_str, wikitext, tags = clean_and_convert_text(raw_text, title)
+            raw_text = ''
+            if title.startswith('Template:'):
+                # Add the original source to the file if it's a Template
+                # Used for reference because the template will be changed completely
+                # Because parts are treated like infoboxes
+                raw_text += wrap_original_mediawiki_source(text_elem.text)
+            raw_text += text_elem.text
+            yaml_str, wikitext, tags = prepare_wikitext(raw_text, title)
+
             if not SKIP_PANDOC and PANDOC_AVAILABLE:
                 wikitext = convert_with_pandoc(wikitext, title)
                 wikitext = cleanup_markdown(wikitext)
@@ -425,44 +475,46 @@ def convert_pages(tree):
     logging.info("✅ Main articles converted")
 
 
-def create_tag_indexes():
+def create_tag_indexes() -> None:
     """Write Obsidian index pages for each collected tag.
 
-    Uses the global tag_to_pages map populated during conversion(`clean_and_convert_text()`)
+    Uses the global tag_to_pages map populated during conversion (`prepare_wikitext()`)
     to emit one markdown file per tag under _indexes/, each with YAML front matter and
     wikilinks to every page in that tag.
 
     Note: Tags and page titles become filenames and wikilinks; weird characters
     will break linking, so both are cleaned with `clean_filename()`.
     """
-    index_dir = os.path.join(OUTPUT_DIR, "_indexes")
+    dir_name = "indexes"
+    index_dir = os.path.join(OUTPUT_DIR, dir_name)
     os.makedirs(index_dir, exist_ok=True)
     for tag, pages in tag_to_pages.items():
-        tag = clean_filename(tag)
+        tag_filename = ' '.join(str(tag).replace('_', ' ').split())
         display_tag = tag
-        yaml_header = extract_yaml_header(f"Index: {display_tag}", tag)
+        yaml_header = build_yaml_header(f"Index: {display_tag}", tag)
         lines = [f"# {display_tag.title()} Index"]
         for page in sorted(pages):
             display_page = clean_filename(page)
             lines.append(f"- [[{display_page}]]")
         content = yaml_header + "\n".join(lines)
-        with open(os.path.join(index_dir, f"_{tag}.md"), "w", encoding="utf-8") as f:
+        with open(os.path.join(index_dir, f"Index {tag_filename}.md"), "w", encoding="utf-8") as f:
             f.write(content)
-    logging.info("📚 Index pages created under _indexes/ with tag references")
+    logging.info(f"📚 Index pages created under {dir_name}/ with tag references")
 
 
-def main():
+def main() -> None:
     logging.info("🔄 Converting MediaWiki XML to Obsidian Vault...")
     try:
         tree = ET.parse(INPUT_XML)
     except ET.ParseError as e:
-        logging.error(f"❌ Failed to parse XML: {e}")
+        logging.error(f"‼️ Failed to parse XML: {e}")
         return
 
     try:
-        extract_wiki_url(tree)
+        global WIKI_URL
+        WIKI_URL = extract_wiki_url(tree)
     except ValueError as e:
-        logging.error(f"❌ {e}")
+        logging.error(f"‼️ {e}")
         return
 
     convert_pages(tree)

--- a/convert.py
+++ b/convert.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import subprocess
 import xml.etree.ElementTree as ET
 from html import unescape
@@ -46,6 +47,13 @@ OUTPUT_DIR = args.output_dir
 SKIP_REDIRECTS = args.skip_redirects
 SKIP_PANDOC = args.skip_pandoc
 COOKIES = args.cookies
+PANDOC_AVAILABLE = shutil.which("pandoc") is not None
+
+if not SKIP_PANDOC and not PANDOC_AVAILABLE:
+    logging.warning(
+        "⚠️ Pandoc not found on PATH. Wikitext will be kept as-is. "
+        "Install Pandoc (https://pandoc.org/installing.html) or pass --skip-pandoc."
+    )
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
@@ -281,6 +289,10 @@ def convert_with_pandoc(text, title=""):
         logging.warning(f"⚠️ Pandoc failed for '{title}'. Using raw text.")
         logging.debug(e.stderr.decode())
         return text
+    except OSError as e:
+        logging.warning(f"⚠️ Pandoc failed for '{title}'. Using raw text.")
+        logging.debug(e)
+        return text
 
 def clean_and_convert_text(raw_text, title):
     """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
@@ -358,7 +370,7 @@ def convert_pages(tree):
 
             raw_text = text_elem.text
             yaml_str, wikitext, tags = clean_and_convert_text(raw_text, title)
-            if not SKIP_PANDOC:
+            if not SKIP_PANDOC and PANDOC_AVAILABLE:
                 wikitext = convert_with_pandoc(wikitext, title)
                 wikitext = cleanup_markdown(wikitext)
             markdown = f"{yaml_str}\n{wikitext.strip()}\n"

--- a/convert.py
+++ b/convert.py
@@ -202,37 +202,37 @@ def download_image(image_name: str) -> Optional[str]:
         return None
 
 
-def infobox_to_dict(template: Template) -> Dict[str, Any]:
-    """Parse an infobox MediaWiki template into a flat dictionary."""
-    infobox_data: Dict[str, Any] = {}
+def template_to_dict(template: Template) -> Dict[str, Any]:
+    """Parse a MediaWiki template invocation into a flat dictionary."""
+    template_data: Dict[str, Any] = {}
 
     raw_name = template.name.strip().lower()
     if raw_name.startswith("infobox_"):
-        infobox_type = raw_name[len("infobox_") :].replace(' ', '_')  # .title()
+        callout_type = raw_name[len("infobox_") :].replace(' ', '_')  # .title()
     else:
-        infobox_type = template.name
+        callout_type = template.name
 
-    infobox_data['infobox'] = infobox_type
+    template_data['callout_type'] = callout_type
 
     for param in template.params:
         key = param.name.strip().replace(":", "").lower()
         val = param.value.strip()
-        infobox_data[key] = val
+        template_data[key] = val
 
-    return infobox_data
+    return template_data
 
 
-def infobox_dict_to_callout(infobox_data: Dict[str, Any]) -> str:
-    """Format an infobox dictionary as an Obsidian callout block."""
+def template_dict_to_callout(template_data: Dict[str, Any]) -> str:
+    """Format a template dictionary as an Obsidian callout block."""
     callout_info = {
-        data: str(infobox_data[data]).replace('\n', '')
-        for data in infobox_data
-        if data not in ('infobox', 'image')  # These are treated differently
+        data: str(template_data[data]).replace('\n', '')
+        for data in template_data
+        if data not in ('callout_type', 'image')  # These are treated differently
     }
 
     callout = ''
-    callout += f'\n> [!{infobox_data['infobox']}]' if infobox_data['infobox'] else '\n> [!NOTE]'
-    if image_name := infobox_data.get('image'):
+    callout += f'\n> [!{template_data['callout_type']}]' if template_data['callout_type'] else '\n> [!NOTE]'
+    if image_name := template_data.get('image'):
         image_name = image_name.strip()
         download_image(image_name)
         callout += f'\n> - **image**: ![[{IMAGE_DIR}/{image_name}]]'
@@ -243,7 +243,7 @@ def infobox_dict_to_callout(infobox_data: Dict[str, Any]) -> str:
     return callout
 
 
-def transform_infobox_to_callout(wikicode: Wikicode) -> Wikicode:
+def transform_templates_to_callouts(wikicode: Wikicode) -> Wikicode:
     """Replace all templates in wikitext with Obsidian callout equivalents."""
     wikicode = copy.deepcopy(wikicode)  # Copy to avoid external mutation
     if len(wikicode.filter_templates()) == 0:
@@ -251,8 +251,8 @@ def transform_infobox_to_callout(wikicode: Wikicode) -> Wikicode:
 
     while template_list := wikicode.filter_templates():
         template = template_list[0]
-        infobox_dict = infobox_to_dict(template)
-        callout = infobox_dict_to_callout(infobox_dict)
+        template_dict = template_to_dict(template)
+        callout = template_dict_to_callout(template_dict)
 
         use_pandoc = not PANDOC_SKIP and PANDOC_AVAILABLE
         callout_to_insert = '\n'
@@ -338,7 +338,7 @@ def remove_obsidian_callout_block(md_text: str) -> str:
     Removes code blocks with language 'obsidian-callout-block' from the markdown text.
 
     This function removes code blocks created as <source lang="obsidian-callout-block">
-    in the transform_infobox_to_callout function. The cleanup is only needed—and only
+    in the transform_templates_to_callouts function. The cleanup is only needed—and only
     takes place—when Pandoc is used, because Pandoc preserves these fenced code blocks.
 
     Args:
@@ -392,7 +392,7 @@ def convert_with_pandoc(text: str, title: str = "") -> str:
 def prepare_wikitext(raw_text: str, title: str) -> Tuple[str, str, List[str]]:
     """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
 
-    Processes categories and images, transforms infoboxes, builds an Obsidian YAML
+    Processes categories and images, transforms templates to callouts, builds an Obsidian YAML
     front matter header, and records tags in the global tag index.
 
     Note: Tags will become a file and a property, weird characters will break linking,
@@ -405,7 +405,7 @@ def prepare_wikitext(raw_text: str, title: str) -> Tuple[str, str, List[str]]:
     wikicode, tags = process_categories(wikicode)
     wikicode = embed_images(wikicode)
 
-    wikicode = transform_infobox_to_callout(wikicode)
+    wikicode = transform_templates_to_callouts(wikicode)
 
     cleaned_text = str(wikicode).strip()
     title = clean_filename(title)
@@ -474,7 +474,7 @@ def convert_pages(tree: ET.ElementTree) -> None:
             if title.startswith('Template:'):
                 # Add the original source to the file if it's a Template
                 # Used for reference because the template will be changed completely
-                # Because parts are treated like infoboxes
+                # Because template invocations are converted to callouts in article wikitext
                 raw_text += wrap_original_mediawiki_source(text_elem.text)
             raw_text += text_elem.text
             yaml_str, wikitext, tags = prepare_wikitext(raw_text, title)

--- a/convert.py
+++ b/convert.py
@@ -56,17 +56,17 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 tag_to_pages = defaultdict(list)
 filename_counts = defaultdict(int)
 
-WIKI_DOMAIN = None
+WIKI_URL = None
 
-def extract_wiki_domain(tree):
-    global WIKI_DOMAIN
+
+def extract_wiki_url(tree):
+    global WIKI_URL
     ns = {"ns": NS}
     base_elem = tree.find(".//ns:siteinfo/ns:base", ns)
     if base_elem is not None and base_elem.text:
         base_url = base_elem.text.strip()
-        match = re.match(r"https?://([^/]+)/", base_url)
-        if match:
-            WIKI_DOMAIN = match.group(1)
+        WIKI_URL = re.match(r"(https?://[^/]+)/", base_url).group(1)
+        if WIKI_URL:
             return
     raise ValueError("Could not extract wiki domain from <base> tag.")
 
@@ -122,14 +122,15 @@ def extract_images(wikicode):
                     images.add(embed_link)
     return wikicode
 
-def get_image_url(wiki_domain, filename):
-    url = f"https://{wiki_domain}/api.php"
+
+def get_image_url(filename):
+    url = f"{WIKI_URL}/api.php"
     params = {
         "action": "query",
         "format": "json",
         "prop": "imageinfo",
         "titles": filename,
-        "iiprop": "url"
+        "iiprop": "url",
     }
     try:
         resp = requests.get(url, params=params, timeout=10)
@@ -153,7 +154,7 @@ def download_image(image_name):
         logging.debug(f"🖼️ Skipping download (already exists): {safe_name}")
         return safe_name
 
-    url = get_image_url(WIKI_DOMAIN, f"File:{image_name}")
+    url = get_image_url(f"File:{image_name}")
     if not url:
         logging.warning(f"❌ Could not find URL for image: {image_name}")
         return None
@@ -398,7 +399,7 @@ def main():
         return
 
     try:
-        extract_wiki_domain(tree)
+        extract_wiki_url(tree)
     except ValueError as e:
         logging.error(f"❌ {e}")
         return

--- a/convert.py
+++ b/convert.py
@@ -11,15 +11,12 @@ import sys
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Union
 import xml.etree.ElementTree as ET
 
-import inflect
 import mwparserfromhell
 from mwparserfromhell.nodes import Template, Wikilink
 from mwparserfromhell.wikicode import Wikicode
 import requests
 from tqdm import tqdm
 import yaml
-
-p: inflect.engine = inflect.engine()
 
 # Constants
 NS = "http://www.mediawiki.org/xml/export-0.11/"
@@ -301,7 +298,6 @@ def clean_heading_ids(md_text: str) -> str:
 
 def fix_links_from_pandoc(md_text: str) -> str:
     """Convert Pandoc wikilink syntax to Obsidian wikilink syntax."""
-
     def replace_wikilinks_no_files(match: re.Match) -> str:
         cleaned_filename = clean_filename(match.group(2).strip().replace('_', ' '))
         text = match.group(3).strip()

--- a/convert.py
+++ b/convert.py
@@ -35,7 +35,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
     parser.add_argument("--skip-redirects", action="store_true", help="Skip redirect pages")
     parser.add_argument(
-        "--skip-pandoc", action="store_true", help="Skip Pandoc conversion even if available"
+        "--pandoc-skip", action="store_true", help="Skip Pandoc conversion even if available"
+    )
+    parser.add_argument(
+        "--pandoc-plain-markdown",
+        action="store_true",
+        help="Use Pandoc --to=markdown instead of the default --to=markdown-raw_attribute",
     )
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     parser.add_argument(
@@ -56,14 +61,15 @@ logging.basicConfig(
 INPUT_XML: str = args.input_xml
 OUTPUT_DIR: str = args.output_dir
 SKIP_REDIRECTS: bool = args.skip_redirects
-SKIP_PANDOC: bool = args.skip_pandoc
+PANDOC_SKIP: bool = args.pandoc_skip
+PANDOC_TO_FORMAT: str = "markdown" if args.pandoc_plain_markdown else "markdown-raw_attribute"
 COOKIES: Optional[str] = args.cookies
 PANDOC_AVAILABLE: bool = shutil.which("pandoc") is not None
 
-if not SKIP_PANDOC and not PANDOC_AVAILABLE:
+if not PANDOC_SKIP and not PANDOC_AVAILABLE:
     logging.warning(
         "⚠️ Pandoc not found on PATH. Wikitext will be kept as-is. "
-        "Install Pandoc (https://pandoc.org/installing.html) or pass --skip-pandoc."
+        "Install Pandoc (https://pandoc.org/installing.html) or pass --pandoc-skip."
     )
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -248,7 +254,7 @@ def transform_infobox_to_callout(wikicode: Wikicode) -> Wikicode:
         infobox_dict = infobox_to_dict(template)
         callout = infobox_dict_to_callout(infobox_dict)
 
-        use_pandoc = not SKIP_PANDOC and PANDOC_AVAILABLE
+        use_pandoc = not PANDOC_SKIP and PANDOC_AVAILABLE
         callout_to_insert = '\n'
         if use_pandoc:
             callout_to_insert += '\n<source lang="obsidian-callout-block">'
@@ -364,7 +370,7 @@ def convert_with_pandoc(text: str, title: str = "") -> str:
     """Convert wikitext to markdown via Pandoc, falling back to raw text on failure."""
     try:
         result = subprocess.run(
-            ['pandoc', '--from=mediawiki', '--to=markdown-raw_attribute', '--wrap=none'],
+            ['pandoc', '--from=mediawiki', f'--to={PANDOC_TO_FORMAT}', '--wrap=none'],
             input=text.encode("utf-8"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -473,7 +479,7 @@ def convert_pages(tree: ET.ElementTree) -> None:
             raw_text += text_elem.text
             yaml_str, wikitext, tags = prepare_wikitext(raw_text, title)
 
-            if not SKIP_PANDOC and PANDOC_AVAILABLE:
+            if not PANDOC_SKIP and PANDOC_AVAILABLE:
                 wikitext = convert_with_pandoc(wikitext, title)
                 wikitext = cleanup_markdown(wikitext)
             markdown = f"{yaml_str}\n{wikitext.strip()}\n"

--- a/convert.py
+++ b/convert.py
@@ -380,13 +380,25 @@ def convert_pages(tree):
             title = title_elem.text.strip()
             logging.debug(f"✅ Found page: {title}")
 
-            revision = page.find(TAG("revision"))
-            if revision is None:
+            latest_revision = None
+            latest_revision_id = None
+            for revision in page.findall(TAG("revision")):
+                try:
+                    revision_id = int(revision.find(TAG("id")).text)
+                except AttributeError:
+                    logging.warning(f"⚠️ No ID in revision for: {title}")
+                    continue
+
+                if latest_revision_id is None or revision_id > latest_revision_id:
+                    latest_revision_id = revision_id
+                    latest_revision = revision
+
+            if latest_revision is None:
                 logging.warning(f"⚠️ No revision for: {title}")
                 pbar.update(1)
                 continue
 
-            text_elem = revision.find(TAG("text"))
+            text_elem = latest_revision.find(TAG("text"))
             if text_elem is None or not text_elem.text or not text_elem.text.strip():
                 logging.warning(f"⚠️ No content in: {title}")
                 pbar.update(1)

--- a/convert.py
+++ b/convert.py
@@ -27,10 +27,12 @@ IMAGE_DIR = "images"
 
 
 def TAG(t: str) -> str:
+    """Return the MediaWiki XML namespace-qualified tag name for element ``t``."""
     return f"{{{NS}}}{t}"
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse and return command-line arguments for the converter."""
     parser = argparse.ArgumentParser(description="Convert MediaWiki XML to Obsidian Vault")
     parser.add_argument("input_xml", help="Input XML file")
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
@@ -76,6 +78,7 @@ WIKI_URL: Optional[str] = None
 
 
 def extract_wiki_url(tree: ET.ElementTree) -> str:
+    """Extract the wiki base URL (scheme + host) from a MediaWiki XML export."""
     ns = {"ns": NS}
     base_elem = tree.find(".//ns:siteinfo/ns:base", ns)
     if base_elem is not None and base_elem.text:
@@ -87,15 +90,20 @@ def extract_wiki_url(tree: ET.ElementTree) -> str:
 
 
 def clean_filename(title: str) -> str:
-    """Convert to safe filename with underscores"""
+    """Convert a page title to a safe filename by replacing forbidden characters to underscores."""
     return re.compile(r'[\\/*?:"<>|{}]').sub('_', title.strip())
 
 
 def normalize_tag(tag: str) -> str:
+    """Normalize a category/tag name for use in filenames and front matter."""
     return re.compile(r'[ \\/*?:"<>|{}]').sub('_', tag.strip())
 
 
 def process_categories(wikicode: Wikicode) -> Tuple[Wikicode, List[str]]:
+    """Extract categories and rewrite their wikilinks to index links.
+
+    Returns (wikicode, categories).
+    """
     wikicode = copy.deepcopy(wikicode)  # Copy to avoid external mutation
     categories = []
     for link in wikicode.ifilter_wikilinks():
@@ -108,6 +116,7 @@ def process_categories(wikicode: Wikicode) -> Tuple[Wikicode, List[str]]:
 
 
 def embed_images(wikicode: Wikicode) -> Wikicode:
+    """Replace file/image wikilinks with Obsidian embeds, downloading images as needed."""
     wikicode = copy.deepcopy(wikicode)  # Copy to avoid external mutation
     images = set()
     nodes = list(wikicode.nodes)  # make a list copy because we'll modify
@@ -130,6 +139,7 @@ def embed_images(wikicode: Wikicode) -> Wikicode:
 
 
 def get_image_url(filename: str) -> Optional[str]:
+    """Query the wiki API for the canonical URL of an image file."""
     url = f"{WIKI_URL}/api.php"
     params = {
         "action": "query",
@@ -153,6 +163,10 @@ def get_image_url(filename: str) -> Optional[str]:
 
 
 def download_image(image_name: str) -> Optional[str]:
+    """Download an image from the wiki into the vault ``OUTPUT_DIR/IMAGE_DIR`` directory.
+
+    Returns the local filename on success, or ``None`` on failure.
+    """
     if not image_name:
         return None
 
@@ -186,6 +200,7 @@ def download_image(image_name: str) -> Optional[str]:
 
 
 def infobox_to_dict(template: Template) -> Dict[str, Any]:
+    """Parse an infobox MediaWiki template into a flat dictionary."""
     infobox_data: Dict[str, Any] = {}
 
     raw_name = template.name.strip().lower()
@@ -205,6 +220,7 @@ def infobox_to_dict(template: Template) -> Dict[str, Any]:
 
 
 def infobox_dict_to_callout(infobox_data: Dict[str, Any]) -> str:
+    """Format an infobox dictionary as an Obsidian callout block."""
     callout_info = {
         data: str(infobox_data[data]).replace('\n', '')
         for data in infobox_data
@@ -225,6 +241,7 @@ def infobox_dict_to_callout(infobox_data: Dict[str, Any]) -> str:
 
 
 def transform_infobox_to_callout(wikicode: Wikicode) -> Wikicode:
+    """Replace all templates in wikitext with Obsidian callout equivalents."""
     wikicode = copy.deepcopy(wikicode)  # Copy to avoid external mutation
     if len(wikicode.filter_templates()) == 0:
         return wikicode
@@ -251,6 +268,7 @@ def transform_infobox_to_callout(wikicode: Wikicode) -> Wikicode:
 
 
 def sanitize_for_yaml(obj: Any) -> Any:
+    """Recursively coerce values to YAML-safe primitives."""
     if isinstance(obj, dict):
         return {sanitize_for_yaml(k): sanitize_for_yaml(v) for k, v in obj.items()}
     elif isinstance(obj, list):
@@ -266,6 +284,7 @@ def build_yaml_header(
     tags: Union[List[str], str],
     extra_fields: Optional[Dict[str, Any]] = None,
 ) -> str:
+    """Build Obsidian-style YAML front matter for a page."""
     # Ensure tags are unique (if tags is a list), but preserve string if given
     tags = list(dict.fromkeys([tags] if isinstance(tags, str) else tags))
     header = {'title': title, 'tags': tags}
@@ -276,10 +295,13 @@ def build_yaml_header(
 
 
 def clean_heading_ids(md_text: str) -> str:
+    """Strip Pandoc-generated heading anchor IDs from markdown."""
     return re.compile(r'^(#{1,6} .+?)\s*\{\#.*?\}', re.MULTILINE).sub(r'\1', md_text)
 
 
 def fix_links_from_pandoc(md_text: str) -> str:
+    """Convert Pandoc wikilink syntax to Obsidian wikilink syntax."""
+
     def replace_wikilinks_no_files(match: re.Match) -> str:
         cleaned_filename = clean_filename(match.group(2).strip().replace('_', ' '))
         text = match.group(3).strip()
@@ -304,11 +326,8 @@ def fix_links_from_pandoc(md_text: str) -> str:
     return md_text_link_files_fixed
 
 
-def clean_residual_wikilink_artifacts(md_text: str) -> str:
-    return md_text.replace(' "wikilink"', '')
-
-
 def fix_image_links(md: str) -> str:
+    """Unescape backslashes before Obsidian image embed syntax."""
     return re.sub(r'\\(!\[\[)', r'\1', md)
 
 
@@ -337,15 +356,16 @@ def remove_obsidian_callout_block(md_text: str) -> str:
 
 
 def cleanup_markdown(md: str) -> str:
+    """Run the full post-Pandoc markdown cleanup pipeline."""
     md = clean_heading_ids(md)
     md = fix_links_from_pandoc(md)
-    md = clean_residual_wikilink_artifacts(md)
     md = fix_image_links(md)
     md = remove_obsidian_callout_block(md)
     return md
 
 
 def convert_with_pandoc(text: str, title: str = "") -> str:
+    """Convert wikitext to markdown via Pandoc, falling back to raw text on failure."""
     try:
         result = subprocess.run(
             ['pandoc', '--from=mediawiki', '--to=markdown-raw_attribute', '--wrap=none'],
@@ -403,6 +423,7 @@ def wrap_original_mediawiki_source(mediawiki_text: str) -> str:
 
 
 def convert_pages(tree: ET.ElementTree) -> None:
+    """Convert all pages in a MediaWiki XML export to markdown files."""
     ns = {"ns": NS}
     total_pages = len(tree.findall(".//ns:page", {"ns": NS}))
 
@@ -503,6 +524,7 @@ def create_tag_indexes() -> None:
 
 
 def main() -> None:
+    """Parse XML, convert pages, and create tag index pages."""
     logging.info("🔄 Converting MediaWiki XML to Obsidian Vault...")
     try:
         tree = ET.parse(INPUT_XML)

--- a/convert.py
+++ b/convert.py
@@ -21,25 +21,33 @@ p = inflect.engine()
 NS = "http://www.mediawiki.org/xml/export-0.11/"
 IMAGE_DIR = "images"
 
+
 def TAG(t):
     return f"{{{NS}}}{t}"
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Convert MediaWiki XML to Obsidian Vault")
     parser.add_argument("input_xml", help="Input XML file")
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
     parser.add_argument("--skip-redirects", action="store_true", help="Skip redirect pages")
-    parser.add_argument("--skip-pandoc", action="store_true", help="Skip Pandoc conversion even if available")
+    parser.add_argument(
+        "--skip-pandoc", action="store_true", help="Skip Pandoc conversion even if available"
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
-    parser.add_argument("--cookies", help="Cookie header value for API/image requests (e.g. 'name=value; other=value')")
+    parser.add_argument(
+        "--cookies",
+        help="Cookie header value for API/image requests (e.g. 'name=value; other=value')",
+    )
     return parser.parse_args()
+
 
 args = parse_args()
 
 logging.basicConfig(
     level=logging.DEBUG if args.verbose else logging.INFO,
     format='%(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 INPUT_XML = args.input_xml
@@ -74,22 +82,26 @@ def extract_wiki_url(tree):
             return
     raise ValueError("Could not extract wiki domain from <base> tag.")
 
+
 def clean_filename(title):
     """Convert to safe filename with underscores"""
     return re.compile(r'[\\/*?:"<>|{}]').sub('_', title.strip())
 
+
 def normalize_tag(tag):
     return tag.replace(" ", "_").lower()
+
 
 def extract_categories(wikicode):
     categories = []
     for link in wikicode.ifilter_wikilinks():
         target = link.title.strip()
         if target.lower().startswith("category:"):
-            cat = target[len("category:"):].strip()
+            cat = target[len("category:") :].strip()
             categories.append(normalize_tag(cat))
             wikicode.remove(link)
     return wikicode, categories
+
 
 def extract_images(wikicode):
     images = set()
@@ -122,7 +134,9 @@ def get_image_url(filename):
         "iiprop": "url",
     }
     try:
-        resp = requests.get(url, params=params, timeout=10, headers={"Cookie": COOKIES} if COOKIES else None)
+        resp = requests.get(
+            url, params=params, timeout=10, headers={"Cookie": COOKIES} if COOKIES else None
+        )
         data = resp.json()
         pages = data.get("query", {}).get("pages", {})
         for page in pages.values():
@@ -132,6 +146,7 @@ def get_image_url(filename):
     except Exception as e:
         logging.error(f"❌ Failed to get image URL for {filename}: {e}")
     return None
+
 
 def download_image(image_name):
     if not image_name:
@@ -164,6 +179,7 @@ def download_image(image_name):
         logging.error(f"❌ Error downloading {image_name}: {e}")
         return None
 
+
 def extract_infobox(wikicode):
     infobox_data = {}
     infobox_template = None
@@ -178,7 +194,7 @@ def extract_infobox(wikicode):
 
     raw_name = infobox_template.name.strip().lower()
     if raw_name.startswith("infobox_"):
-        infobox_type = raw_name[len("infobox_"):].replace(' ', '_').title()
+        infobox_type = raw_name[len("infobox_") :].replace(' ', '_').title()
     else:
         infobox_type = infobox_template.name
 
@@ -214,6 +230,7 @@ def extract_infobox(wikicode):
 
     return wikicode, infobox_data
 
+
 def sanitize_for_yaml(obj):
     if isinstance(obj, dict):
         return {sanitize_for_yaml(k): sanitize_for_yaml(v) for k, v in obj.items()}
@@ -224,12 +241,14 @@ def sanitize_for_yaml(obj):
     else:
         return str(obj)
 
+
 def extract_yaml_header(title, tags, extra_fields=None):
     header = {'title': title, 'tags': tags}
     if extra_fields:
         header.update(sanitize_for_yaml(extra_fields))
 
     return f"---\n{yaml.safe_dump(header, sort_keys=False)}---\n"
+
 
 def clean_heading_ids(md_text):
     return re.compile(r'^(#{1,6} .+?)\s*\{\#.*?\}', re.MULTILINE).sub(r'\1', md_text)
@@ -263,8 +282,10 @@ def fix_links_from_pandoc(md_text):
 def clean_residual_wikilink_artifacts(md_text):
     return md_text.replace(' "wikilink"', '')
 
+
 def fix_image_links(md):
     return re.sub(r'\\(!\[\[)', r'\1', md)
+
 
 def cleanup_markdown(md):
     md = clean_heading_ids(md)
@@ -273,6 +294,7 @@ def cleanup_markdown(md):
     md = fix_image_links(md)
     return md
 
+
 def convert_with_pandoc(text, title=""):
     try:
         result = subprocess.run(
@@ -280,7 +302,7 @@ def convert_with_pandoc(text, title=""):
             input=text.encode("utf-8"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            check=True
+            check=True,
         )
         md = result.stdout.decode("utf-8")
         md = md.replace("\\'", "'")
@@ -293,6 +315,7 @@ def convert_with_pandoc(text, title=""):
         logging.warning(f"⚠️ Pandoc failed for '{title}'. Using raw text.")
         logging.debug(e)
         return text
+
 
 def clean_and_convert_text(raw_text, title):
     """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
@@ -334,6 +357,7 @@ def clean_and_convert_text(raw_text, title):
         tag_to_pages[tag].append(title)
 
     return yaml_header, cleaned_text, tags
+
 
 def convert_pages(tree):
     ns = {"ns": NS}
@@ -388,6 +412,7 @@ def convert_pages(tree):
 
     logging.info("✅ Main articles converted")
 
+
 def create_tag_indexes():
     """Write Obsidian index pages for each collected tag.
 
@@ -413,6 +438,7 @@ def create_tag_indexes():
             f.write(content)
     logging.info("📚 Index pages created under _indexes/ with tag references")
 
+
 def main():
     logging.info("🔄 Converting MediaWiki XML to Obsidian Vault...")
     try:
@@ -430,6 +456,7 @@ def main():
     convert_pages(tree)
     create_tag_indexes()
     logging.info(f"✅ All done! Markdown vault ready at: {OUTPUT_DIR}")
+
 
 if __name__ == "__main__":
     main()

--- a/convert.py
+++ b/convert.py
@@ -28,6 +28,7 @@ def parse_args():
     parser.add_argument("input_xml", help="Input XML file")
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
     parser.add_argument("--skip-redirects", action="store_true", help="Skip redirect pages")
+    parser.add_argument("--skip-pandoc", action="store_true", help="Skip Pandoc conversion even if available")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     parser.add_argument("--cookies", help="Cookie header value for API/image requests (e.g. 'name=value; other=value')")
     return parser.parse_args()
@@ -43,6 +44,7 @@ logging.basicConfig(
 INPUT_XML = args.input_xml
 OUTPUT_DIR = args.output_dir
 SKIP_REDIRECTS = args.skip_redirects
+SKIP_PANDOC = args.skip_pandoc
 COOKIES = args.cookies
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -356,8 +358,9 @@ def convert_pages(tree):
 
             raw_text = text_elem.text
             yaml_str, wikitext, tags = clean_and_convert_text(raw_text, title)
-            wikitext = convert_with_pandoc(wikitext, title)
-            wikitext = cleanup_markdown(wikitext)
+            if not SKIP_PANDOC:
+                wikitext = convert_with_pandoc(wikitext, title)
+                wikitext = cleanup_markdown(wikitext)
             markdown = f"{yaml_str}\n{wikitext.strip()}\n"
             base_filename = clean_filename(title)
             count = filename_counts[base_filename]

--- a/convert.py
+++ b/convert.py
@@ -29,6 +29,7 @@ def parse_args():
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
     parser.add_argument("--skip-redirects", action="store_true", help="Skip redirect pages")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument("--cookies", help="Cookie header value for API/image requests (e.g. 'name=value; other=value')")
     return parser.parse_args()
 
 args = parse_args()
@@ -42,6 +43,7 @@ logging.basicConfig(
 INPUT_XML = args.input_xml
 OUTPUT_DIR = args.output_dir
 SKIP_REDIRECTS = args.skip_redirects
+COOKIES = args.cookies
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
@@ -110,7 +112,7 @@ def get_image_url(filename):
         "iiprop": "url",
     }
     try:
-        resp = requests.get(url, params=params, timeout=10)
+        resp = requests.get(url, params=params, timeout=10, headers={"Cookie": COOKIES} if COOKIES else None)
         data = resp.json()
         pages = data.get("query", {}).get("pages", {})
         for page in pages.values():
@@ -137,7 +139,7 @@ def download_image(image_name):
         return None
 
     try:
-        resp = requests.get(url, stream=True)
+        resp = requests.get(url, stream=True, headers={"Cookie": COOKIES} if COOKIES else None)
         if resp.status_code == 200:
             os.makedirs(os.path.dirname(filepath), exist_ok=True)
             with open(filepath, "wb") as f:

--- a/convert.py
+++ b/convert.py
@@ -109,7 +109,7 @@ def extract_images(wikicode):
     for i, node in enumerate(nodes):
         if isinstance(node, mwparserfromhell.wikicode.Wikilink):
             target = node.title.strip()
-            if target.lower().startswith(("file:", "image:")):
+            if target.lower().startswith(("file:", "image:", "media:")):
                 image_name = target.split(":", 1)[1].strip()
                 local_filename = download_image(image_name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ mwparserfromhell~=0.7.2
 requests~=2.34.2
 pyyaml~=6.0.3
 tqdm~=4.68.1
-inflect~=7.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-mwparserfromhell
-requests
-pyyaml
-tqdm
-inflect
+mwparserfromhell~=0.7.2
+requests~=2.34.2
+pyyaml~=6.0.3
+tqdm~=4.68.1
+inflect~=7.5.0
+pandoc~=2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ requests~=2.34.2
 pyyaml~=6.0.3
 tqdm~=4.68.1
 inflect~=7.5.0
-pandoc~=2.4

--- a/test.py
+++ b/test.py
@@ -1,55 +1,46 @@
+"""Unit tests for convert.py.
+
+Pandoc link post-processing tests reflect output from Pandoc 3.9.0.2.
+"""
+
 import pytest
 import mwparserfromhell
 from convert import (
-    clean_wikilink,
-    fix_wikilink_spacing,
     clean_heading_ids,
-    extract_links_from_pandoc,
+    fix_links_from_pandoc,
     extract_yaml_header,
     extract_infobox,
     clean_and_convert_text,
 )
 
-# Test 1: Wikilink formatting
-def test_clean_wikilink_simple():
-    assert clean_wikilink("Foo_Bar") == "[[Foo Bar]]"
-
-def test_clean_wikilink_with_alias():
-    assert clean_wikilink("Foo_Bar|Alias") == "[[Foo Bar|Alias]]"
-
-def test_fix_wikilink_spacing():
-    text = "This is a [[Foo_Bar]] and a [[Baz_Bat|Alias]] link."
-    result = fix_wikilink_spacing(text)
-    assert result == "This is a [[Foo Bar]] and a [[Baz Bat|Alias]] link."
-
-# Test 2: Heading cleanup
+# Test 1: Heading cleanup
 def test_clean_heading_ids():
     md = "# Heading 1 {#heading1}\n## Heading 2 {#heading2}"
     expected = "# Heading 1\n## Heading 2"
     assert clean_heading_ids(md) == expected
 
-# Test 3: Pandoc-style link cleanup
-def test_extract_links_from_pandoc_internal():
-    md = 'This is a [Foo Bar](Foo_Bar "wikilink") and [Alias](Target_Page "wikilink").'
+# Test 2: Pandoc-style link cleanup
+def test_fix_links_from_pandoc_internal():
+    md = 'This is a [Foo Bar](Foo_Bar "Foo Bar"){.wikilink} and [Alias](Target_Page "Alias"){.wikilink}.'
     expected = 'This is a [[Foo Bar]] and [[Target Page|Alias]].'
-    assert extract_links_from_pandoc(md) == expected
+    assert fix_links_from_pandoc(md) == expected
 
-def test_extract_links_from_pandoc_external():
+def test_fix_links_from_pandoc_external():
     md = 'Visit [Google](https://google.com) or contact [me](mailto:test@example.com).'
-    assert extract_links_from_pandoc(md) == md  # Should remain unchanged
+    assert fix_links_from_pandoc(md) == md  # Should remain unchanged
 
-# Test 4: YAML frontmatter generation
+# Test 3: YAML frontmatter generation
 def test_extract_yaml_header_basic():
-    title = "Sample_Page"
+    title = "Sample_Page Title"
     tags = ["category_one", "tag_two"]
     yaml = extract_yaml_header(title, tags)
     assert "---" in yaml
-    assert "title: Sample Page" in yaml
+    assert "title: Sample_Page Title" in yaml # Spaces Shouldn't be converted into underscores
     assert "tags:" in yaml
     assert "- category_one" in yaml
     assert "- tag_two" in yaml
 
-# Test 5: Infobox parsing and tag inference
+# Test 4: Infobox parsing and tag inference
 def test_extract_infobox_and_tags():
     wikitext = """
 {{Infobox_character

--- a/test.py
+++ b/test.py
@@ -1,72 +1,116 @@
+# # contents of test_module.py with source code and the test
+# from pathlib import Path
+
+
+# def getssh():
+#     """Simple function to return expanded homedir ssh path."""
+#     print(Path.home())
+#     return Path.home() / ".ssh"
+
+
+# def test_getssh(monkeypatch):
+#     # mocked return function to replace Path.home
+#     # always return '/abc'
+#     def mockreturn():
+#         return Path("/abc")
+
+#     # Application of the monkeypatch to replace Path.home
+#     # with the behavior of mockreturn defined above.
+#     monkeypatch.setattr(Path, "home", lambda: '/abcX')
+
+#     # Calling getssh() will use mockreturn in place of Path.home
+#     # for this test with the monkeypatch.
+#     x = getssh()
+#     assert x == Path("/abc/.ssh")
+
+
 """Unit tests for convert.py.
 
 Pandoc link post-processing tests reflect output from Pandoc 3.9.0.2.
 """
 
+from multiprocessing import context
 import pytest
 import mwparserfromhell
+import convert
 from convert import (
     clean_heading_ids,
     fix_links_from_pandoc,
-    extract_yaml_header,
-    extract_infobox,
-    clean_and_convert_text,
+    build_yaml_header,
+    transform_infobox_to_callout,
 )
 
+
 # Test 1: Heading cleanup
-def test_clean_heading_ids():
+def test_clean_heading_ids() -> None:
     md = "# Heading 1 {#heading1}\n## Heading 2 {#heading2}"
     expected = "# Heading 1\n## Heading 2"
     assert clean_heading_ids(md) == expected
 
+
 # Test 2: Pandoc-style link cleanup
-def test_fix_links_from_pandoc_internal():
+def test_fix_links_from_pandoc_internal() -> None:
     md = 'This is a [Foo Bar](Foo_Bar "Foo Bar"){.wikilink} and [Alias](Target_Page "Alias"){.wikilink}.'
     expected = 'This is a [[Foo Bar]] and [[Target Page|Alias]].'
     assert fix_links_from_pandoc(md) == expected
 
-def test_fix_links_from_pandoc_external():
+
+def test_fix_links_from_pandoc_external() -> None:
     md = 'Visit [Google](https://google.com) or contact [me](mailto:test@example.com).'
     assert fix_links_from_pandoc(md) == md  # Should remain unchanged
 
+
 # Test 3: YAML frontmatter generation
-def test_extract_yaml_header_basic():
+def test_build_yaml_header_basic() -> None:
     title = "Sample_Page Title"
     tags = ["category_one", "tag_two"]
-    yaml = extract_yaml_header(title, tags)
+    yaml = build_yaml_header(title, tags)
     assert "---" in yaml
-    assert "title: Sample_Page Title" in yaml # Spaces Shouldn't be converted into underscores
+    assert "title: Sample_Page Title" in yaml  # Spaces Shouldn't be converted into underscores
     assert "tags:" in yaml
     assert "- category_one" in yaml
     assert "- tag_two" in yaml
 
+
+# def test_with_monkeypatch(monkeypatch):
+#     monkeypatch.setattr('sys.argv', ['prog', '--input', 'file.txt', '--verbose'])
+#     args = parse_args()
+#     assert args.input == 'file.txt'
+#     assert args.verbose is True
+
+
 # Test 4: Infobox parsing and tag inference
-def test_extract_infobox_and_tags():
-    wikitext = """
-{{Infobox_character
+def test_transform_infobox_to_callout(monkeypatch) -> None:
+    # Forcing pandoc skipping
+    monkeypatch.setattr(convert, 'SKIP_PANDOC', True)
+    # print(convert.SKIP_PANDOC)
+    # if convert.SKIP_PANDOC:
+    #     print('skipping')
+    # else:
+    #     print('no skipping')
+    wikitext = """{{Infobox_character
 | name = Aragorn
 | race = [[Human]]
 | weapon = [[Andúril]]
+| info = More info in [[More info]]
 }}
-[[Category:Characters]]
-"""
+[[Category:Characters]]"""
+
+    wikitext_with_callout = """
+
+> [!character]
+> - **name**: Aragorn
+> - **race**: [[Human]]
+> - **weapon**: [[Andúril]]
+> - **info**: More info in [[More info]]
+
+[[Category:Characters]]"""
+
     wikicode = mwparserfromhell.parse(wikitext)
-    cleaned_wikicode, infobox = extract_infobox(wikicode)
+    cleaned_wikicode = transform_infobox_to_callout(wikicode)
 
-    assert infobox["infobox"] == "Character"
-    assert "name" in infobox
-    assert "race" in infobox
-    assert infobox["weapon"] == ["[[Andúril]]"]
+    print(f'> wikicode: <<{wikicode}>>')
+    print(f'> cleaned_wikicode: <<{cleaned_wikicode}>>')
+    print(f'> wikitext_with_callout: <<{wikitext_with_callout}>>')
 
-def test_clean_and_convert_text_adds_infobox_tag():
-    wikitext = """
-{{Infobox_artifact
-| name = One Ring
-| creator = [[Sauron]]
-}}
-[[Category:Items]]
-"""
-    yaml, text, tags = clean_and_convert_text(wikitext, "One_Ring")
-    assert "artifacts" in [t.lower() for t in tags]
-    assert "items" in [t.lower() for t in tags]
-    assert "---" in yaml
+    assert wikitext_with_callout == cleaned_wikicode

--- a/test.py
+++ b/test.py
@@ -9,7 +9,7 @@ from convert import (
     clean_heading_ids,
     fix_links_from_pandoc,
     build_yaml_header,
-    transform_infobox_to_callout,
+    transform_templates_to_callouts,
 )
 
 
@@ -44,8 +44,8 @@ def test_build_yaml_header_basic() -> None:
     assert "- tag_two" in yaml
 
 
-# Test 4: Infobox parsing and tag inference
-def test_transform_infobox_to_callout(monkeypatch) -> None:
+# Test 4: Template parsing and callout conversion
+def test_transform_templates_to_callouts(monkeypatch) -> None:
     monkeypatch.setattr(convert, "PANDOC_SKIP", True)
     wikitext = """{{Infobox_character
 | name = Aragorn
@@ -66,6 +66,6 @@ def test_transform_infobox_to_callout(monkeypatch) -> None:
 [[Category:Characters]]"""
 
     wikicode = mwparserfromhell.parse(wikitext)
-    cleaned_wikicode = transform_infobox_to_callout(wikicode)
+    cleaned_wikicode = transform_templates_to_callouts(wikicode)
 
     assert str(cleaned_wikicode) == wikitext_with_callout

--- a/test.py
+++ b/test.py
@@ -9,6 +9,8 @@ from convert import (
     clean_heading_ids,
     fix_links_from_pandoc,
     build_yaml_header,
+    build_mediawiki_page_url,
+    build_source_fields,
     transform_templates_to_callouts,
 )
 
@@ -42,6 +44,54 @@ def test_build_yaml_header_basic() -> None:
     assert "tags:" in yaml
     assert "- category_one" in yaml
     assert "- tag_two" in yaml
+
+
+def test_build_mediawiki_page_url_pretty() -> None:
+    convert.WIKI_BASE_URL = "https://en.wikipedia.org/wiki/Main_Page"
+    assert build_mediawiki_page_url("Aragorn") == "https://en.wikipedia.org/wiki/Aragorn"
+    assert (
+        build_mediawiki_page_url("Template:Infobox character")
+        == "https://en.wikipedia.org/wiki/Template:Infobox_character"
+    )
+
+
+def test_build_mediawiki_page_url_index_php() -> None:
+    convert.WIKI_BASE_URL = "https://www.mediawiki.org/w/index.php?title=Main_Page"
+    assert (
+        build_mediawiki_page_url("Help:Contents")
+        == "https://www.mediawiki.org/w/index.php?title=Help%3AContents"
+    )
+
+
+def test_extract_wiki_url_reads_generator() -> None:
+    import xml.etree.ElementTree as ET
+
+    xml = """<?xml version="1.0"?>
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/">
+  <siteinfo>
+    <base>https://en.wikipedia.org/wiki/Main_Page</base>
+    <generator>MediaWiki 1.41.0</generator>
+  </siteinfo>
+</mediawiki>"""
+    tree = ET.ElementTree(ET.fromstring(xml))
+    wiki_url, base_url, generator = convert.extract_wiki_url(tree)
+    assert wiki_url == "https://en.wikipedia.org"
+    assert base_url == "https://en.wikipedia.org/wiki/Main_Page"
+    assert generator == "MediaWiki 1.41.0"
+
+
+def test_build_yaml_header_with_source() -> None:
+    convert.WIKI_URL = "https://example.com"
+    convert.WIKI_BASE_URL = "https://example.com/wiki/Main_Page"
+    convert.WIKI_GENERATOR = "MediaWiki 1.41.0"
+    yaml = build_yaml_header(
+        "Sample Page",
+        ["tag"],
+        extra_fields=build_source_fields("Sample Page", "2024-06-18T10:30:00Z"),
+    )
+    assert "source/note: Imported from MediaWiki 1.41.0 website @ https://example.com" in yaml
+    assert "source/url: https://example.com/wiki/Sample_Page" in yaml
+    assert "source/date: '2024-06-18T10:30:00Z'" in yaml
 
 
 # Test 4: Template parsing and callout conversion

--- a/test.py
+++ b/test.py
@@ -1,36 +1,8 @@
-# # contents of test_module.py with source code and the test
-# from pathlib import Path
-
-
-# def getssh():
-#     """Simple function to return expanded homedir ssh path."""
-#     print(Path.home())
-#     return Path.home() / ".ssh"
-
-
-# def test_getssh(monkeypatch):
-#     # mocked return function to replace Path.home
-#     # always return '/abc'
-#     def mockreturn():
-#         return Path("/abc")
-
-#     # Application of the monkeypatch to replace Path.home
-#     # with the behavior of mockreturn defined above.
-#     monkeypatch.setattr(Path, "home", lambda: '/abcX')
-
-#     # Calling getssh() will use mockreturn in place of Path.home
-#     # for this test with the monkeypatch.
-#     x = getssh()
-#     assert x == Path("/abc/.ssh")
-
-
 """Unit tests for convert.py.
 
 Pandoc link post-processing tests reflect output from Pandoc 3.9.0.2.
 """
 
-from multiprocessing import context
-import pytest
 import mwparserfromhell
 import convert
 from convert import (
@@ -72,22 +44,9 @@ def test_build_yaml_header_basic() -> None:
     assert "- tag_two" in yaml
 
 
-# def test_with_monkeypatch(monkeypatch):
-#     monkeypatch.setattr('sys.argv', ['prog', '--input', 'file.txt', '--verbose'])
-#     args = parse_args()
-#     assert args.input == 'file.txt'
-#     assert args.verbose is True
-
-
 # Test 4: Infobox parsing and tag inference
 def test_transform_infobox_to_callout(monkeypatch) -> None:
-    # Forcing pandoc skipping
-    monkeypatch.setattr(convert, 'SKIP_PANDOC', True)
-    # print(convert.SKIP_PANDOC)
-    # if convert.SKIP_PANDOC:
-    #     print('skipping')
-    # else:
-    #     print('no skipping')
+    monkeypatch.setattr(convert, "PANDOC_SKIP", True)
     wikitext = """{{Infobox_character
 | name = Aragorn
 | race = [[Human]]
@@ -109,8 +68,4 @@ def test_transform_infobox_to_callout(monkeypatch) -> None:
     wikicode = mwparserfromhell.parse(wikitext)
     cleaned_wikicode = transform_infobox_to_callout(wikicode)
 
-    print(f'> wikicode: <<{wikicode}>>')
-    print(f'> cleaned_wikicode: <<{cleaned_wikicode}>>')
-    print(f'> wikitext_with_callout: <<{wikitext_with_callout}>>')
-
-    assert wikitext_with_callout == cleaned_wikicode
+    assert str(cleaned_wikicode) == wikitext_with_callout


### PR DESCRIPTION
Hi Michael, cool project. Thanks for building it, I'm using it for a Mediawiki website I don't want to keep maintaining but I still want the content for myself. So I reviewed the export and found a couple of things that needed to be improved/fixed. I did some testing and found it to be working, I also updated the `test.py` file to reflect the changes I did.


## Summary

  This PR bundles a round of robustness, authentication, and Obsidian-compatibility
  improvements to the MediaWiki → Markdown converter, plus significantly expanded
  documentation.

  ## Changes

  ### Conversion & Pandoc handling
  - Gracefully handle a missing Pandoc instead of crashing: detect it at startup via
    `shutil.which`, warn if absent, and skip conversion automatically (not just when
    `--skip-pandoc` is passed). `OSError` in `convert_with_pandoc` now falls back cleanly.
  - Add a `--skip-pandoc` flag to bypass Pandoc conversion entirely.

  ### Authentication & media
  - Add an optional `--cookies` flag so API and image requests can send a session
    Cookie header for wikis that require login.
  - Refactor wiki URL handling to store the full base URL (protocol + domain) instead
    of just the domain; `WIKI_DOMAIN`→`WIKI_URL`, `extract_wiki_domain`→`extract_wiki_url`,
    and `get_image_url` now uses the global directly.
  - Include `media:` links in `extract_images` (previously only `file:` and `image:`).

  ### Obsidian compatibility
  - Standardize Obsidian-safe filenames and wikilink conversion using `clean_filename`.
  - Rewrite Pandoc link cleanup to handle wikilinks and inline file embeds; remove
    redundant helpers and inline single-use regexes.
  - Keep underscores in YAML titles instead of converting them to spaces.

  ### Docs & housekeeping
  - Expand the README: Pandoc/venv/conda setup, platform-specific install steps, a guide
    for creating MediaWiki XML dumps (CLI and `Special:Export`), and the new
    `--skip-pandoc` / `--cookies` flags.
  - Call out the tested **Pandoc 3.9.0.2** requirement prominently.
  - Update `requirements.txt` for compatibility and drop `pandoc` as a pip dependency.
  - Add a `.gitignore` (Python cache, virtualenvs, test artifacts, IDE files) and apply
    consistent formatting to `convert.py`.

  ## Tests
  - Drop tests for removed wikilink spacing helpers; rename/update Pandoc link tests for
    `{.wikilink}` syntax; assert YAML titles retain underscores.

  ## Stats
  `5 files changed, 485 insertions(+), 110 deletions(-)` — `convert.py`, `README.md`,
  `test.py`, `requirements.txt`, `.gitignore`.

  ## Latest revision used
  I added and fixed the code done in https://github.com/kw217/mediawiki-to-markdown/commit/26f7b23d010e4c83837727390fa331a69ecc8967
