### PR TITLE
Mediawiki to markdown additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Unit test / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.nox/
+coverage.xml
+*.cover
+.hypothesis/
+
+# Type checkers
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pytype/
+
+# Linters / formatters
+.ruff_cache/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# IDE
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ If you find this script useful, please consider supporting me on Patreon:
 - Python 3.8+ (already installed — see **Installation** below for the rest)
 - [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it)
 
+  Pandoc integration (including wikilink post-processing) has been tested with **Pandoc 3.9.0.2**. Other versions may work, but Pandoc's Markdown output can change between releases.
+
 Python dependencies are listed in `requirements.txt`. All packages use pinned versions (`~=`) for compatibility across environments. You are free to remove the version constraints and try the latest (or older) releases if you prefer — just keep in mind that unpinned installs may introduce breaking changes.
 
 | Package            | Purpose                                |

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ If you find this script useful, please consider supporting me on Patreon:
 
 ## 📦 Requirements
 
-- Python 3.8+ (already installed — see **Installation** below for the rest)
-- [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it)
+> **⚠️ Tested Pandoc version: 3.9.0.2**
+>
+> Pandoc integration (including wikilink post-processing) is tested against **Pandoc 3.9.0.2**. Other versions may work, but Pandoc's Markdown output can change between releases — if your version differs, conversion results may not match what was tested here.
 
-  Pandoc integration (including wikilink post-processing) has been tested with **Pandoc 3.9.0.2**. Other versions may work, but Pandoc's Markdown output can change between releases.
+- Python 3.8+ (already installed — see **Installation** below for the rest)
+- [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it). Install **3.9.0.2** when possible (see callout above).
 
 Python dependencies are listed in `requirements.txt`. All packages use pinned versions (`~=`) for compatibility across environments. You are free to remove the version constraints and try the latest (or older) releases if you prefer — just keep in mind that unpinned installs may introduce breaking changes.
 
@@ -52,7 +54,11 @@ These steps assume **Python 3.8+ is already installed**. Clone or download this 
 
 ### 1. Install the Pandoc CLI (optional but recommended)
 
-`convert.py` uses Pandoc when available for wikitext-to-Markdown conversion and wikilink cleanup. Without it, the script still runs but leaves raw wikitext in place. You can also pass `--skip-pandoc` at runtime to bypass conversion even when Pandoc is installed. Install the CLI once for your operating system:
+`convert.py` uses Pandoc when available for wikitext-to-Markdown conversion and wikilink cleanup. Without it, the script still runs but leaves raw wikitext in place. You can also pass `--skip-pandoc` at runtime to bypass conversion even when Pandoc is installed.
+
+**Use Pandoc 3.9.0.2** — the version this project is tested against (see **Requirements**). Package managers often ship older releases; download the matching build from the [Pandoc install page](https://pandoc.org/installing.html) if needed.
+
+Install the CLI once for your operating system:
 
 > **Using Conda?** You can install Pandoc with `conda install -c conda-forge pandoc` inside your environment — see **Option B — Conda** below and skip this step.
 
@@ -221,10 +227,11 @@ With your environment activated:
 python convert.py --help
 ```
 
-You should see the script's help text. If you installed Pandoc, also check:
+You should see the script's help text. If you installed Pandoc, confirm the version matches **3.9.0.2** (the tested version):
 
 ```bash
 pandoc --version
+# Expected first line: pandoc 3.9.0.2
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ This script converts a MediaWiki XML dump into a clean, tag-driven Markdown vaul
 - 🏷️ Extracts and normalizes categories as `tags`
 - 📦 Converts infoboxes into YAML frontmatter (including images)
 - 🔧 Infers tags from infobox types using noun inflection
-- 🖼️ Downloads and embeds images as `![[images/Filename]]`
-- 🔗 Converts internal links to `[[Wikilinks]]`
+- 🖼️ Downloads and embeds images as `![[images/Filename]]` (supports `File:`, `Image:`, and `Media:` links)
+- 🔗 Converts internal links to Obsidian-safe `[[Wikilinks]]` via Pandoc post-processing
 - 📚 Automatically generates tag-based index files under `_indexes/`
-- 🐢 Supports optional Pandoc for better Markdown rendering
+- 🐢 Uses Pandoc for wikitext-to-Markdown conversion when available (recommended; falls back to raw wikitext on failure)
+- ⏭️ Optional `--skip-pandoc` flag to bypass Pandoc conversion entirely and keep raw wikitext
+- 🔐 Optional `--cookies` flag for authenticated wikis (private wikis, login-required image downloads)
 - 🔍 Verbose mode for detailed output and easier troubleshooting
 
 ## Support
@@ -29,33 +31,296 @@ If you find this script useful, please consider supporting me on Patreon:
 
 ## 📦 Requirements
 
-- Python 3.8+
-- [`pandoc`](https://pandoc.org/) (optional, but recommended for better Markdown conversion)
+- Python 3.8+ (already installed — see **Installation** below for the rest)
+- [Pandoc](https://pandoc.org/installing.html) CLI on your `PATH` — **optional but recommended** for proper Markdown and wikilink conversion (or pass `--skip-pandoc` to skip it)
 
-Install Python dependencies with:
+Python dependencies are listed in `requirements.txt`. All packages use pinned versions (`~=`) for compatibility across environments. You are free to remove the version constraints and try the latest (or older) releases if you prefer — just keep in mind that unpinned installs may introduce breaking changes.
+
+| Package            | Purpose                                |
+| ------------------ | -------------------------------------- |
+| `mwparserfromhell` | Parse and manipulate wikitext          |
+| `requests`         | Download images from the wiki API      |
+| `pyyaml`           | Generate YAML frontmatter              |
+| `tqdm`             | Progress bar during conversion         |
+| `inflect`          | Infer tags from infobox template names |
+
+## 🛠️ Installation
+
+These steps assume **Python 3.8+ is already installed**. Clone or download this repository, then open a terminal in the project folder (`mediawiki-to-markdown`).
+
+### 1. Install the Pandoc CLI (optional but recommended)
+
+`convert.py` uses Pandoc when available for wikitext-to-Markdown conversion and wikilink cleanup. Without it, the script still runs but leaves raw wikitext in place. You can also pass `--skip-pandoc` at runtime to bypass conversion even when Pandoc is installed. Install the CLI once for your operating system:
+
+> **Using Conda?** You can install Pandoc with `conda install -c conda-forge pandoc` inside your environment — see **Option B — Conda** below and skip this step.
+
+<details>
+<summary><strong>macOS</strong></summary>
+
+With [Homebrew](https://brew.sh/):
 
 ```bash
+brew install pandoc
+```
+
+Or download the macOS package from the [Pandoc install page](https://pandoc.org/installing.html).
+
+Verify:
+
+```bash
+pandoc --version
+```
+
+</details>
+
+<details>
+<summary><strong>Linux</strong></summary>
+
+**Debian / Ubuntu:**
+
+```bash
+sudo apt update
+sudo apt install pandoc
+```
+
+**Fedora:**
+
+```bash
+sudo dnf install pandoc
+```
+
+**Arch Linux:**
+
+```bash
+sudo pacman -S pandoc
+```
+
+Or use your distribution's package manager, or the [official Linux tarball](https://pandoc.org/installing.html).
+
+Verify:
+
+```bash
+pandoc --version
+```
+
+</details>
+
+<details>
+<summary><strong>Windows</strong></summary>
+
+Pick one of these options:
+
+**winget** (Windows 10/11):
+
+```powershell
+winget install JohnMacFarlane.Pandoc
+```
+
+**Chocolatey:**
+
+```powershell
+choco install pandoc
+```
+
+**Installer:** download the `.msi` from the [Pandoc install page](https://pandoc.org/installing.html) and run it. Restart your terminal afterward so `PATH` updates.
+
+Verify in **Command Prompt** or **PowerShell**:
+
+```powershell
+pandoc --version
+```
+
+</details>
+
+### 2. Install Python dependencies
+
+Choose **venv** (built into Python) or **Conda** (if you already use it).
+
+#### Option A — venv (recommended)
+
+<details>
+<summary><strong>macOS / Linux</strong></summary>
+
+```bash
+cd mediawiki-to-markdown
+
+python3 -m venv .venv
+source .venv/bin/activate
+
 pip install -r requirements.txt
 ```
+
+To deactivate later: `deactivate`
+
+</details>
+
+<details>
+<summary><strong>Windows (Command Prompt)</strong></summary>
+
+```bat
+cd mediawiki-to-markdown
+
+python -m venv .venv
+.venv\Scripts\activate.bat
+
+pip install -r requirements.txt
+```
+
+To deactivate later: `deactivate`
+
+</details>
+
+<details>
+<summary><strong>Windows (PowerShell)</strong></summary>
+
+```powershell
+cd mediawiki-to-markdown
+
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+
+pip install -r requirements.txt
+```
+
+If activation is blocked by execution policy, run once (as Administrator):
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+To deactivate later: `deactivate`
+
+</details>
+
+#### Option B — Conda
+
+Works the same on macOS, Linux, and Windows. Conda can install Pandoc alongside your Python dependencies in one environment:
+
+```bash
+cd mediawiki-to-markdown
+
+conda create -n mediawiki-md python=3.8
+conda activate mediawiki-md
+
+conda install -c conda-forge pandoc
+
+pip install -r requirements.txt
+```
+
+To deactivate later: `conda deactivate`
+
+> **Tip:** If you install Pandoc here, you can skip step 1 above.
+
+### 3. Verify the setup
+
+With your environment activated:
+
+```bash
+python convert.py --help
+```
+
+You should see the script's help text. If you installed Pandoc, also check:
+
+```bash
+pandoc --version
+```
+
+---
+
+## 📥 Creating the input XML file
+
+`convert.py` expects a MediaWiki XML export — the same format produced by [Special:Export](https://www.mediawiki.org/wiki/Special:Export) or `dumpBackup.php`. The file must include a `<base>` URL in `<siteinfo>` so the script can resolve image downloads.
+
+### CLI (preferred)
+
+If you have shell access to the MediaWiki server, use the maintenance script. This is the simplest and most reliable option for full or partial exports.
+
+From the wiki root directory:
+
+```bash
+# Current revision of every page
+php maintenance/run.php dumpBackup --current > wiki-dump.xml
+
+# Full revision history
+php maintenance/run.php dumpBackup --full > wiki-dump-full.xml
+
+# Specific namespaces only (0 = main, 10 = Template, 14 = Category, etc.)
+php maintenance/run.php dumpBackup --current --namespaces 0,10,14 > partial-dump.xml
+
+# Pages listed in a text file (one title per line)
+php maintenance/run.php dumpBackup --current --pagelist pages.txt > selected.xml
+```
+
+On older MediaWiki installations you may need to run the script directly from the `maintenance/` folder:
+
+```bash
+cd maintenance
+php dumpBackup.php --current > ../wiki-dump.xml
+```
+
+See the [dumpBackup.php manual](https://www.mediawiki.org/wiki/Manual:DumpBackup.php) for all options.
+
+### Web (Special:Export)
+
+Use this when you do not have server access, or only need a small set of pages.
+
+1. Open `Special:Export` on your wiki (e.g. `https://your-wiki.example/wiki/Special:Export`).
+2. Enter page titles — one per line — in the text box. For a single page you can also visit `Special:Export/Page_Title` directly.
+3. Optionally check **Include templates** so transcluded templates are exported too.
+4. Optionally check **Export all revisions** to include full history (limited to 100 revisions per page via the web UI).
+5. Click **Export** and save the downloaded XML file.
+
+For scripted exports over HTTP, you can POST to `Special:Export` with curl:
+
+```bash
+curl -d "pages=Main_Page&pages=Another_Page&action=submit" \
+  "https://your-wiki.example/wiki/Special:Export" \
+  -o wiki-export.xml
+```
+
+See [Help:Export](https://www.mediawiki.org/wiki/Help:Export) and [Parameters to Special:Export](https://www.mediawiki.org/wiki/Manual:Parameters_to_Special:Export) for details.
+
+> **Tip:** If your export does not include templates, pages that rely on them may not render correctly after conversion. Include templates in the export when possible.
+
+---
 
 ## 🚀 Usage
 
 ```bash
-python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--verbose]
+python convert.py INPUT_XML [OUTPUT_DIR] [--skip-redirects] [--skip-pandoc] [--verbose] [--cookies COOKIES]
 ```
 
-| Argument           | Description                                         |
-| ------------------ | --------------------------------------------------- |
-| `INPUT_XML`        | Path to your MediaWiki XML dump                     |
-| `OUTPUT_DIR`       | Optional output folder (default: `obsidian_vault/`) |
-| `--skip-redirects` | Ignore redirect pages                               |
-| `--verbose`        | Enable verbose logging (disables progress bar)      |
+| Argument           | Description                                                                 |
+| ------------------ | --------------------------------------------------------------------------- |
+| `INPUT_XML`        | Path to your MediaWiki XML dump                                             |
+| `OUTPUT_DIR`       | Optional output folder (default: `obsidian_vault/`)                          |
+| `--skip-redirects` | Ignore redirect pages                                                       |
+| `--skip-pandoc`    | Skip Pandoc conversion and wikilink cleanup, even if Pandoc is installed     |
+| `--verbose`        | Enable verbose logging (disables progress bar)                              |
+| `--cookies`        | Cookie header for authenticated API/image requests (see below)              |
 
+### Skipping Pandoc (`--skip-pandoc`)
+
+Use this when you do not have Pandoc installed, or when you prefer to keep the original wikitext (e.g. for manual cleanup later). Categories, infoboxes, images, and YAML frontmatter are still processed — only the Pandoc Markdown conversion and post-processing step is skipped.
+
+```bash
+python convert.py wiki-dump.xml --skip-pandoc
+```
+
+### Authenticated wikis (`--cookies`)
+
+If the wiki requires login to access images or the API, copy the `Cookie` header from an authenticated browser session (e.g. Developer Tools → Network → any request → Request Headers) and pass it to the script:
+
+```bash
+python convert.py wiki-dump.xml --cookies "sessionid=abc123; csrftoken=xyz789"
+```
+
+---
 
 ## 🗂️ Output Structure
 
 ```text
-chronicler_vault/
+obsidian_vault/
 ├── _indexes/
 │   ├── _people.md
 │   ├── _locations.md

--- a/convert.py
+++ b/convert.py
@@ -20,14 +20,6 @@ p = inflect.engine()
 NS = "http://www.mediawiki.org/xml/export-0.11/"
 IMAGE_DIR = "images"
 
-# Pre-compiled regex patterns
-INVALID_FILENAME_CHARS = re.compile(r'[\\/*?:"<>|]')
-HEADING_ID_REGEX = re.compile(r'^(#{1,6} .+?)\s*\{\#.*?\}', re.MULTILINE)
-WIKILINK_REGEX = re.compile(r'\[\[(.*?)\]\]', re.DOTALL)
-PANDOC_LINK_REGEX = re.compile(
-    r'\[([^\]]+)\]\(((?:[^\(\)]+|\([^\)]*\))+)(?:\s+"wikilink")?\)'
-)
-
 def TAG(t):
     return f"{{{NS}}}{t}"
 
@@ -72,25 +64,10 @@ def extract_wiki_url(tree):
 
 def clean_filename(title):
     """Convert to safe filename with underscores"""
-    return INVALID_FILENAME_CHARS.sub('_', title.strip())
+    return re.compile(r'[\\/*?:"<>|{}]').sub('_', title.strip())
 
 def normalize_tag(tag):
     return tag.replace(" ", "_").lower()
-
-def display_title(title):
-    """Convert to human-readable title with spaces"""
-    return title.replace('_', ' ')
-
-def clean_wikilink(link_content):
-    """Centralized wikilink cleaning"""
-    if '|' in link_content:
-        target, alias = link_content.split('|', 1)
-        return f"[[{target.replace('_', ' ')}|{alias}]]"
-    return f"[[{link_content.replace('_', ' ')}]]"
-
-def fix_wikilink_spacing(text):
-    """Convert underscores to spaces in wikilinks using centralized cleaner"""
-    return WIKILINK_REGEX.sub(lambda m: clean_wikilink(m.group(1)), text)
 
 def extract_categories(wikicode):
     categories = []
@@ -199,7 +176,7 @@ def extract_infobox(wikicode):
         key = param.name.strip().replace(":", "").lower()
         val = param.value.strip()
 
-        wikilinks = WIKILINK_REGEX.findall(val)
+        wikilinks = re.compile(r'\[\[(.*?)\]\]', re.DOTALL).findall(val)
         if wikilinks:
             parts = []
             remaining = val
@@ -236,33 +213,40 @@ def sanitize_for_yaml(obj):
         return str(obj)
 
 def extract_yaml_header(title, tags, extra_fields=None):
-    header = {
-        'title': display_title(title),
-        'tags': tags
-    }
+    header = {'title': title, 'tags': tags}
     if extra_fields:
         header.update(sanitize_for_yaml(extra_fields))
 
     return f"---\n{yaml.safe_dump(header, sort_keys=False)}---\n"
 
 def clean_heading_ids(md_text):
-    return HEADING_ID_REGEX.sub(r'\1', md_text)
+    return re.compile(r'^(#{1,6} .+?)\s*\{\#.*?\}', re.MULTILINE).sub(r'\1', md_text)
 
-def extract_links_from_pandoc(md_text):
-    def replacer(match):
-        text = match.group(1).strip()
-        target = match.group(2).replace(' "wikilink"', '').strip()
 
-        if target.startswith(('http://', 'https://', 'mailto:')):
-            return match.group(0)
-
-        clean_target = display_title(target)
-        # Only include alias if it's actually different
-        if text == clean_target:
-            return f"[[{clean_target}]]"
+def fix_links_from_pandoc(md_text):
+    def replace_wikilinks_no_files(match: re.Match):
+        cleaned_filename = clean_filename(match.group(2).strip().replace('_', ' '))
+        text = match.group(3).strip()
+        if cleaned_filename == text:
+            return f'[[{cleaned_filename}]]'
         else:
-            return f"[[{clean_target}|{text}]]"
-    return PANDOC_LINK_REGEX.sub(replacer, md_text)
+            return f'[[{cleaned_filename}|{text}]]'
+
+    pandoc_wikilink_no_files_regex = re.compile(r'(?<!!)\[([^]]+)\]\(([^ ]+) "(.+?)"\)({[^}]+})?')
+    md_text_link_no_files_fixed = pandoc_wikilink_no_files_regex.sub(
+        replace_wikilinks_no_files, md_text
+    )
+
+    def replace_wikilink_inline_files(match: re.Match):
+        text = match.group(3).strip()
+        return f'![[{text}]]'
+
+    pandoc_wikilink_inline_files_regex = re.compile(r'\\*!\[([^]]+)\]\(([^ ]+) "(.+?)"\)({[^}]+})?')
+    md_text_link_files_fixed = pandoc_wikilink_inline_files_regex.sub(
+        replace_wikilink_inline_files, md_text_link_no_files_fixed
+    )
+    return md_text_link_files_fixed
+
 
 def clean_residual_wikilink_artifacts(md_text):
     return md_text.replace(' "wikilink"', '')
@@ -272,9 +256,8 @@ def fix_image_links(md):
 
 def cleanup_markdown(md):
     md = clean_heading_ids(md)
-    md = extract_links_from_pandoc(md)
+    md = fix_links_from_pandoc(md)
     md = clean_residual_wikilink_artifacts(md)
-    md = fix_wikilink_spacing(md)
     md = fix_image_links(md)
     return md
 
@@ -296,11 +279,23 @@ def convert_with_pandoc(text, title=""):
         return text
 
 def clean_and_convert_text(raw_text, title):
+    """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
+
+    Extracts categories, images, and infobox data; builds an Obsidian YAML
+    front matter header; and records tags in the global tag index.
+
+    Note: Tags will become a file and a property, weird characters will break linking,
+    cleaning for good filenames with `clean_filename()`
+
+    Returns (yaml_header, cleaned_wikitext, tags).
+    """
     text = unescape(raw_text)
     wikicode = mwparserfromhell.parse(text)
     wikicode, tags = extract_categories(wikicode)
     wikicode = extract_images(wikicode)
     wikicode, infobox_data = extract_infobox(wikicode)
+
+    tags = [clean_filename(tag) for tag in tags]
 
     # Conditionally infer tag
     if infobox_data.get('infobox'):
@@ -315,6 +310,7 @@ def clean_and_convert_text(raw_text, title):
             tags.append(inferred_tag)
 
     cleaned_text = str(wikicode).strip()
+    title = clean_filename(title)
     yaml_header = extract_yaml_header(title, tags, infobox_data)
 
     # Track tags for index
@@ -376,14 +372,24 @@ def convert_pages(tree):
     logging.info("✅ Main articles converted")
 
 def create_tag_indexes():
+    """Write Obsidian index pages for each collected tag.
+
+    Uses the global tag_to_pages map populated during conversion(`clean_and_convert_text()`)
+    to emit one markdown file per tag under _indexes/, each with YAML front matter and
+    wikilinks to every page in that tag.
+
+    Note: Tags and page titles become filenames and wikilinks; weird characters
+    will break linking, so both are cleaned with `clean_filename()`.
+    """
     index_dir = os.path.join(OUTPUT_DIR, "_indexes")
     os.makedirs(index_dir, exist_ok=True)
     for tag, pages in tag_to_pages.items():
-        display_tag = display_title(tag)
+        tag = clean_filename(tag)
+        display_tag = tag
         yaml_header = extract_yaml_header(f"Index: {display_tag}", tag)
         lines = [f"# {display_tag.title()} Index"]
         for page in sorted(pages):
-            display_page = display_title(page)
+            display_page = clean_filename(page)
             lines.append(f"- [[{display_page}]]")
         content = yaml_header + "\n".join(lines)
         with open(os.path.join(index_dir, f"_{tag}.md"), "w", encoding="utf-8") as f:

--- a/convert.py
+++ b/convert.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import subprocess
 import xml.etree.ElementTree as ET
 from html import unescape
@@ -46,6 +47,13 @@ OUTPUT_DIR = args.output_dir
 SKIP_REDIRECTS = args.skip_redirects
 SKIP_PANDOC = args.skip_pandoc
 COOKIES = args.cookies
+PANDOC_AVAILABLE = shutil.which("pandoc") is not None
+
+if not SKIP_PANDOC and not PANDOC_AVAILABLE:
+    logging.warning(
+        "⚠️ Pandoc not found on PATH. Wikitext will be kept as-is. "
+        "Install Pandoc (https://pandoc.org/installing.html) or pass --skip-pandoc."
+    )
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
@@ -281,6 +289,10 @@ def convert_with_pandoc(text, title=""):
         logging.warning(f"⚠️ Pandoc failed for '{title}'. Using raw text.")
         logging.debug(e.stderr.decode())
         return text
+    except OSError as e:
+        logging.warning(f"⚠️ Pandoc failed for '{title}'. Using raw text.")
+        logging.debug(e)
+        return text
 
 def clean_and_convert_text(raw_text, title):
     """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
@@ -358,7 +370,7 @@ def convert_pages(tree):
 
             raw_text = text_elem.text
             yaml_str, wikitext, tags = clean_and_convert_text(raw_text, title)
-            if not SKIP_PANDOC:
+            if not SKIP_PANDOC and PANDOC_AVAILABLE:
                 wikitext = convert_with_pandoc(wikitext, title)
                 wikitext = cleanup_markdown(wikitext)
             markdown = f"{yaml_str}\n{wikitext.strip()}\n"

--- a/convert.py
+++ b/convert.py
@@ -56,17 +56,17 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 tag_to_pages = defaultdict(list)
 filename_counts = defaultdict(int)
 
-WIKI_DOMAIN = None
+WIKI_URL = None
 
-def extract_wiki_domain(tree):
-    global WIKI_DOMAIN
+
+def extract_wiki_url(tree):
+    global WIKI_URL
     ns = {"ns": NS}
     base_elem = tree.find(".//ns:siteinfo/ns:base", ns)
     if base_elem is not None and base_elem.text:
         base_url = base_elem.text.strip()
-        match = re.match(r"https?://([^/]+)/", base_url)
-        if match:
-            WIKI_DOMAIN = match.group(1)
+        WIKI_URL = re.match(r"(https?://[^/]+)/", base_url).group(1)
+        if WIKI_URL:
             return
     raise ValueError("Could not extract wiki domain from <base> tag.")
 
@@ -122,14 +122,15 @@ def extract_images(wikicode):
                     images.add(embed_link)
     return wikicode
 
-def get_image_url(wiki_domain, filename):
-    url = f"https://{wiki_domain}/api.php"
+
+def get_image_url(filename):
+    url = f"{WIKI_URL}/api.php"
     params = {
         "action": "query",
         "format": "json",
         "prop": "imageinfo",
         "titles": filename,
-        "iiprop": "url"
+        "iiprop": "url",
     }
     try:
         resp = requests.get(url, params=params, timeout=10)
@@ -153,7 +154,7 @@ def download_image(image_name):
         logging.debug(f"🖼️ Skipping download (already exists): {safe_name}")
         return safe_name
 
-    url = get_image_url(WIKI_DOMAIN, f"File:{image_name}")
+    url = get_image_url(f"File:{image_name}")
     if not url:
         logging.warning(f"❌ Could not find URL for image: {image_name}")
         return None
@@ -398,7 +399,7 @@ def main():
         return
 
     try:
-        extract_wiki_domain(tree)
+        extract_wiki_url(tree)
     except ValueError as e:
         logging.error(f"❌ {e}")
         return

--- a/convert.py
+++ b/convert.py
@@ -380,13 +380,25 @@ def convert_pages(tree):
             title = title_elem.text.strip()
             logging.debug(f"✅ Found page: {title}")
 
-            revision = page.find(TAG("revision"))
-            if revision is None:
+            latest_revision = None
+            latest_revision_id = None
+            for revision in page.findall(TAG("revision")):
+                try:
+                    revision_id = int(revision.find(TAG("id")).text)
+                except AttributeError:
+                    logging.warning(f"⚠️ No ID in revision for: {title}")
+                    continue
+
+                if latest_revision_id is None or revision_id > latest_revision_id:
+                    latest_revision_id = revision_id
+                    latest_revision = revision
+
+            if latest_revision is None:
                 logging.warning(f"⚠️ No revision for: {title}")
                 pbar.update(1)
                 continue
 
-            text_elem = revision.find(TAG("text"))
+            text_elem = latest_revision.find(TAG("text"))
             if text_elem is None or not text_elem.text or not text_elem.text.strip():
                 logging.warning(f"⚠️ No content in: {title}")
                 pbar.update(1)

--- a/convert.py
+++ b/convert.py
@@ -21,25 +21,33 @@ p = inflect.engine()
 NS = "http://www.mediawiki.org/xml/export-0.11/"
 IMAGE_DIR = "images"
 
+
 def TAG(t):
     return f"{{{NS}}}{t}"
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Convert MediaWiki XML to Obsidian Vault")
     parser.add_argument("input_xml", help="Input XML file")
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
     parser.add_argument("--skip-redirects", action="store_true", help="Skip redirect pages")
-    parser.add_argument("--skip-pandoc", action="store_true", help="Skip Pandoc conversion even if available")
+    parser.add_argument(
+        "--skip-pandoc", action="store_true", help="Skip Pandoc conversion even if available"
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
-    parser.add_argument("--cookies", help="Cookie header value for API/image requests (e.g. 'name=value; other=value')")
+    parser.add_argument(
+        "--cookies",
+        help="Cookie header value for API/image requests (e.g. 'name=value; other=value')",
+    )
     return parser.parse_args()
+
 
 args = parse_args()
 
 logging.basicConfig(
     level=logging.DEBUG if args.verbose else logging.INFO,
     format='%(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 INPUT_XML = args.input_xml
@@ -74,22 +82,26 @@ def extract_wiki_url(tree):
             return
     raise ValueError("Could not extract wiki domain from <base> tag.")
 
+
 def clean_filename(title):
     """Convert to safe filename with underscores"""
     return re.compile(r'[\\/*?:"<>|{}]').sub('_', title.strip())
 
+
 def normalize_tag(tag):
     return tag.replace(" ", "_").lower()
+
 
 def extract_categories(wikicode):
     categories = []
     for link in wikicode.ifilter_wikilinks():
         target = link.title.strip()
         if target.lower().startswith("category:"):
-            cat = target[len("category:"):].strip()
+            cat = target[len("category:") :].strip()
             categories.append(normalize_tag(cat))
             wikicode.remove(link)
     return wikicode, categories
+
 
 def extract_images(wikicode):
     images = set()
@@ -122,7 +134,9 @@ def get_image_url(filename):
         "iiprop": "url",
     }
     try:
-        resp = requests.get(url, params=params, timeout=10, headers={"Cookie": COOKIES} if COOKIES else None)
+        resp = requests.get(
+            url, params=params, timeout=10, headers={"Cookie": COOKIES} if COOKIES else None
+        )
         data = resp.json()
         pages = data.get("query", {}).get("pages", {})
         for page in pages.values():
@@ -132,6 +146,7 @@ def get_image_url(filename):
     except Exception as e:
         logging.error(f"❌ Failed to get image URL for {filename}: {e}")
     return None
+
 
 def download_image(image_name):
     if not image_name:
@@ -164,6 +179,7 @@ def download_image(image_name):
         logging.error(f"❌ Error downloading {image_name}: {e}")
         return None
 
+
 def extract_infobox(wikicode):
     infobox_data = {}
     infobox_template = None
@@ -178,7 +194,7 @@ def extract_infobox(wikicode):
 
     raw_name = infobox_template.name.strip().lower()
     if raw_name.startswith("infobox_"):
-        infobox_type = raw_name[len("infobox_"):].replace(' ', '_').title()
+        infobox_type = raw_name[len("infobox_") :].replace(' ', '_').title()
     else:
         infobox_type = infobox_template.name
 
@@ -214,6 +230,7 @@ def extract_infobox(wikicode):
 
     return wikicode, infobox_data
 
+
 def sanitize_for_yaml(obj):
     if isinstance(obj, dict):
         return {sanitize_for_yaml(k): sanitize_for_yaml(v) for k, v in obj.items()}
@@ -224,12 +241,14 @@ def sanitize_for_yaml(obj):
     else:
         return str(obj)
 
+
 def extract_yaml_header(title, tags, extra_fields=None):
     header = {'title': title, 'tags': tags}
     if extra_fields:
         header.update(sanitize_for_yaml(extra_fields))
 
     return f"---\n{yaml.safe_dump(header, sort_keys=False)}---\n"
+
 
 def clean_heading_ids(md_text):
     return re.compile(r'^(#{1,6} .+?)\s*\{\#.*?\}', re.MULTILINE).sub(r'\1', md_text)
@@ -263,8 +282,10 @@ def fix_links_from_pandoc(md_text):
 def clean_residual_wikilink_artifacts(md_text):
     return md_text.replace(' "wikilink"', '')
 
+
 def fix_image_links(md):
     return re.sub(r'\\(!\[\[)', r'\1', md)
+
 
 def cleanup_markdown(md):
     md = clean_heading_ids(md)
@@ -273,6 +294,7 @@ def cleanup_markdown(md):
     md = fix_image_links(md)
     return md
 
+
 def convert_with_pandoc(text, title=""):
     try:
         result = subprocess.run(
@@ -280,7 +302,7 @@ def convert_with_pandoc(text, title=""):
             input=text.encode("utf-8"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            check=True
+            check=True,
         )
         md = result.stdout.decode("utf-8")
         md = md.replace("\\'", "'")
@@ -293,6 +315,7 @@ def convert_with_pandoc(text, title=""):
         logging.warning(f"⚠️ Pandoc failed for '{title}'. Using raw text.")
         logging.debug(e)
         return text
+
 
 def clean_and_convert_text(raw_text, title):
     """Parse MediaWiki wikitext and prepare it for Pandoc conversion.
@@ -334,6 +357,7 @@ def clean_and_convert_text(raw_text, title):
         tag_to_pages[tag].append(title)
 
     return yaml_header, cleaned_text, tags
+
 
 def convert_pages(tree):
     ns = {"ns": NS}
@@ -388,6 +412,7 @@ def convert_pages(tree):
 
     logging.info("✅ Main articles converted")
 
+
 def create_tag_indexes():
     """Write Obsidian index pages for each collected tag.
 
@@ -413,6 +438,7 @@ def create_tag_indexes():
             f.write(content)
     logging.info("📚 Index pages created under _indexes/ with tag references")
 
+
 def main():
     logging.info("🔄 Converting MediaWiki XML to Obsidian Vault...")
     try:
@@ -430,6 +456,7 @@ def main():
     convert_pages(tree)
     create_tag_indexes()
     logging.info(f"✅ All done! Markdown vault ready at: {OUTPUT_DIR}")
+
 
 if __name__ == "__main__":
     main()

--- a/convert.py
+++ b/convert.py
@@ -28,6 +28,7 @@ def parse_args():
     parser.add_argument("input_xml", help="Input XML file")
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
     parser.add_argument("--skip-redirects", action="store_true", help="Skip redirect pages")
+    parser.add_argument("--skip-pandoc", action="store_true", help="Skip Pandoc conversion even if available")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     parser.add_argument("--cookies", help="Cookie header value for API/image requests (e.g. 'name=value; other=value')")
     return parser.parse_args()
@@ -43,6 +44,7 @@ logging.basicConfig(
 INPUT_XML = args.input_xml
 OUTPUT_DIR = args.output_dir
 SKIP_REDIRECTS = args.skip_redirects
+SKIP_PANDOC = args.skip_pandoc
 COOKIES = args.cookies
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -356,8 +358,9 @@ def convert_pages(tree):
 
             raw_text = text_elem.text
             yaml_str, wikitext, tags = clean_and_convert_text(raw_text, title)
-            wikitext = convert_with_pandoc(wikitext, title)
-            wikitext = cleanup_markdown(wikitext)
+            if not SKIP_PANDOC:
+                wikitext = convert_with_pandoc(wikitext, title)
+                wikitext = cleanup_markdown(wikitext)
             markdown = f"{yaml_str}\n{wikitext.strip()}\n"
             base_filename = clean_filename(title)
             count = filename_counts[base_filename]

--- a/convert.py
+++ b/convert.py
@@ -29,6 +29,7 @@ def parse_args():
     parser.add_argument("output_dir", nargs="?", default="obsidian_vault", help="Output directory")
     parser.add_argument("--skip-redirects", action="store_true", help="Skip redirect pages")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument("--cookies", help="Cookie header value for API/image requests (e.g. 'name=value; other=value')")
     return parser.parse_args()
 
 args = parse_args()
@@ -42,6 +43,7 @@ logging.basicConfig(
 INPUT_XML = args.input_xml
 OUTPUT_DIR = args.output_dir
 SKIP_REDIRECTS = args.skip_redirects
+COOKIES = args.cookies
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
@@ -110,7 +112,7 @@ def get_image_url(filename):
         "iiprop": "url",
     }
     try:
-        resp = requests.get(url, params=params, timeout=10)
+        resp = requests.get(url, params=params, timeout=10, headers={"Cookie": COOKIES} if COOKIES else None)
         data = resp.json()
         pages = data.get("query", {}).get("pages", {})
         for page in pages.values():
@@ -137,7 +139,7 @@ def download_image(image_name):
         return None
 
     try:
-        resp = requests.get(url, stream=True)
+        resp = requests.get(url, stream=True, headers={"Cookie": COOKIES} if COOKIES else None)
         if resp.status_code == 200:
             os.makedirs(os.path.dirname(filepath), exist_ok=True)
             with open(filepath, "wb") as f:

--- a/convert.py
+++ b/convert.py
@@ -109,7 +109,7 @@ def extract_images(wikicode):
     for i, node in enumerate(nodes):
         if isinstance(node, mwparserfromhell.wikicode.Wikilink):
             target = node.title.strip()
-            if target.lower().startswith(("file:", "image:")):
+            if target.lower().startswith(("file:", "image:", "media:")):
                 image_name = target.split(":", 1)[1].strip()
                 local_filename = download_image(image_name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-mwparserfromhell
-requests
-pyyaml
-tqdm
-inflect
+mwparserfromhell~=0.7.2
+requests~=2.34.2
+pyyaml~=6.0.3
+tqdm~=4.68.1
+inflect~=7.5.0
+pandoc~=2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ requests~=2.34.2
 pyyaml~=6.0.3
 tqdm~=4.68.1
 inflect~=7.5.0
-pandoc~=2.4

--- a/test.py
+++ b/test.py
@@ -1,55 +1,46 @@
+"""Unit tests for convert.py.
+
+Pandoc link post-processing tests reflect output from Pandoc 3.9.0.2.
+"""
+
 import pytest
 import mwparserfromhell
 from convert import (
-    clean_wikilink,
-    fix_wikilink_spacing,
     clean_heading_ids,
-    extract_links_from_pandoc,
+    fix_links_from_pandoc,
     extract_yaml_header,
     extract_infobox,
     clean_and_convert_text,
 )
 
-# Test 1: Wikilink formatting
-def test_clean_wikilink_simple():
-    assert clean_wikilink("Foo_Bar") == "[[Foo Bar]]"
-
-def test_clean_wikilink_with_alias():
-    assert clean_wikilink("Foo_Bar|Alias") == "[[Foo Bar|Alias]]"
-
-def test_fix_wikilink_spacing():
-    text = "This is a [[Foo_Bar]] and a [[Baz_Bat|Alias]] link."
-    result = fix_wikilink_spacing(text)
-    assert result == "This is a [[Foo Bar]] and a [[Baz Bat|Alias]] link."
-
-# Test 2: Heading cleanup
+# Test 1: Heading cleanup
 def test_clean_heading_ids():
     md = "# Heading 1 {#heading1}\n## Heading 2 {#heading2}"
     expected = "# Heading 1\n## Heading 2"
     assert clean_heading_ids(md) == expected
 
-# Test 3: Pandoc-style link cleanup
-def test_extract_links_from_pandoc_internal():
-    md = 'This is a [Foo Bar](Foo_Bar "wikilink") and [Alias](Target_Page "wikilink").'
+# Test 2: Pandoc-style link cleanup
+def test_fix_links_from_pandoc_internal():
+    md = 'This is a [Foo Bar](Foo_Bar "Foo Bar"){.wikilink} and [Alias](Target_Page "Alias"){.wikilink}.'
     expected = 'This is a [[Foo Bar]] and [[Target Page|Alias]].'
-    assert extract_links_from_pandoc(md) == expected
+    assert fix_links_from_pandoc(md) == expected
 
-def test_extract_links_from_pandoc_external():
+def test_fix_links_from_pandoc_external():
     md = 'Visit [Google](https://google.com) or contact [me](mailto:test@example.com).'
-    assert extract_links_from_pandoc(md) == md  # Should remain unchanged
+    assert fix_links_from_pandoc(md) == md  # Should remain unchanged
 
-# Test 4: YAML frontmatter generation
+# Test 3: YAML frontmatter generation
 def test_extract_yaml_header_basic():
-    title = "Sample_Page"
+    title = "Sample_Page Title"
     tags = ["category_one", "tag_two"]
     yaml = extract_yaml_header(title, tags)
     assert "---" in yaml
-    assert "title: Sample Page" in yaml
+    assert "title: Sample_Page Title" in yaml # Spaces Shouldn't be converted into underscores
     assert "tags:" in yaml
     assert "- category_one" in yaml
     assert "- tag_two" in yaml
 
-# Test 5: Infobox parsing and tag inference
+# Test 4: Infobox parsing and tag inference
 def test_extract_infobox_and_tags():
     wikitext = """
 {{Infobox_character


### PR DESCRIPTION
Hi Michael, cool project. Thanks for building it, I'm using it for a Mediawiki website I don't want to keep maintaining but I still want the content for myself. So I reviewed the export and found a couple of things that needed to be improved/fixed. I did some testing and found it to be working, I also updated the `test.py` file to reflect the changes I did.

I had an older pull request, that I now have closed because the project on my side was diverging, so I'm creating a new pull request with the code that was intended for this repository and the new one now diverges, see it here: https://github.com/caballerofelipe/mediawiki-to-obsidian .


## Summary

  This PR bundles a round of robustness, authentication, and Obsidian-compatibility
  improvements to the MediaWiki → Markdown converter, plus significantly expanded
  documentation.

  ## Changes

  ### Conversion & Pandoc handling
  - Gracefully handle a missing Pandoc instead of crashing: detect it at startup via
    `shutil.which`, warn if absent, and skip conversion automatically (not just when
    `--skip-pandoc` is passed). `OSError` in `convert_with_pandoc` now falls back cleanly.
  - Add a `--skip-pandoc` flag to bypass Pandoc conversion entirely.

  ### Authentication & media
  - Add an optional `--cookies` flag so API and image requests can send a session
    Cookie header for wikis that require login.
  - Refactor wiki URL handling to store the full base URL (protocol + domain) instead
    of just the domain; `WIKI_DOMAIN`→`WIKI_URL`, `extract_wiki_domain`→`extract_wiki_url`,
    and `get_image_url` now uses the global directly.
  - Include `media:` links in `extract_images` (previously only `file:` and `image:`).

  ### Obsidian compatibility
  - Standardize Obsidian-safe filenames and wikilink conversion using `clean_filename`.
  - Rewrite Pandoc link cleanup to handle wikilinks and inline file embeds; remove
    redundant helpers and inline single-use regexes.
  - Keep underscores in YAML titles instead of converting them to spaces.

  ### Docs & housekeeping
  - Expand the README: Pandoc/venv/conda setup, platform-specific install steps, a guide
    for creating MediaWiki XML dumps (CLI and `Special:Export`), and the new
    `--skip-pandoc` / `--cookies` flags.
  - Call out the tested **Pandoc 3.9.0.2** requirement prominently.
  - Update `requirements.txt` for compatibility and drop `pandoc` as a pip dependency.
  - Add a `.gitignore` (Python cache, virtualenvs, test artifacts, IDE files) and apply
    consistent formatting to `convert.py`.

  ## Tests
  - Drop tests for removed wikilink spacing helpers; rename/update Pandoc link tests for
    `{.wikilink}` syntax; assert YAML titles retain underscores.

  ## Stats
  `5 files changed, 485 insertions(+), 110 deletions(-)` — `convert.py`, `README.md`,
  `test.py`, `requirements.txt`, `.gitignore`.

  ## Latest revision used
  I added and fixed the code done in https://github.com/kw217/mediawiki-to-markdown/commit/26f7b23d010e4c83837727390fa331a69ecc8967
